### PR TITLE
fix: [길거리 음식점 리스트 화면] 방문인증 체크박스 체크 후, 가게 클릭 시 터치한 가게와 다른 가게로 이동하는 오류 …

### DIFF
--- a/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListReactor.swift
+++ b/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListReactor.swift
@@ -131,9 +131,18 @@ final class StreetFoodListReactor: BaseReactor, Reactor {
             
         case .tapStore(let index):
             let selectedIndex = self.currentState.advertisement == nil ? index : index - 1
-            let selectedStore = self.currentState.stores[selectedIndex]
+            var selectedStore: Store?
             
-            return .just(.pushStoreDetail(storeId: Int(selectedStore.id) ?? 0))
+            if self.currentState.isOnlyCertificated {
+                let filteredStores = self.currentState.stores.filter {
+                    $0.visitHistory.isCertified
+                }
+                
+                selectedStore = filteredStores[selectedIndex]
+            } else {
+                selectedStore = self.currentState.stores[selectedIndex]
+            }
+            return .just(.pushStoreDetail(storeId: Int(selectedStore?.id ?? "0") ?? 0))
             
         case .tapAdvertisement:
             guard let advertisement = self.currentState.advertisement else { return .empty() }


### PR DESCRIPTION
### Overview
Linked Issue: #32 

### 해결 방법
인증된 가게만 체크 여부와 상관없이 가지고 있는 전체 가게 리스트에서 선택한 인덱스를 조회하고 있었습니다.  
즉, 인증된 가게 체크와 무관하게 체크 안된 상태의 리스트 데이터를 조회하고 있었습니다.  
인증된 가게 체크 시, 인증된 가게 리스트에서 조회되도록 수정했습니다.

### ScreenShot

https://user-images.githubusercontent.com/7058293/197323014-9cf8d943-a633-4053-ad1a-62a6f385d99b.MP4

