### PR TITLE
fix: [길거리 음식점 리스트 화면] 인증된 가게만 체크박스 체크해도 지도상의 마커가 변하지 않는 오류 수정. #33

### DIFF
--- a/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListViewController.swift
+++ b/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListViewController.swift
@@ -111,7 +111,10 @@ final class StreetFoodListViewController: BaseViewController, StreetFoodListCoor
         
         reactor.state
             .map { state -> [StreetFoodListSectionModel] in
-                let mapSection = StreetFoodListSectionModel(stores: state.stores)
+                let mapSection = StreetFoodListSectionModel(
+                    stores: state.stores,
+                    isOnlyCertificated: state.isOnlyCertificated
+                )
                 let storeSection = StreetFoodListSectionModel(
                     stores: state.stores,
                     advertisement: state.advertisement,

--- a/3dollar-in-my-pocket/model/presentation/StreetFoodListSectionModel.swift
+++ b/3dollar-in-my-pocket/model/presentation/StreetFoodListSectionModel.swift
@@ -19,8 +19,14 @@ extension StreetFoodListSectionModel: SectionModelType {
         self.items = items
     }
     
-    init(stores: [Store]) {
-        self.items = [.map(stores)]
+    init(stores: [Store], isOnlyCertificated: Bool) {
+        if isOnlyCertificated {
+            let filteredStores = stores.filter { $0.visitHistory.isCertified }
+            
+            self.items = [.map(filteredStores)]
+        } else {
+            self.items = [.map(stores)]
+        }
     }
     
     init(stores: [Store], advertisement: Advertisement?, isOnlyCertificated: Bool) {


### PR DESCRIPTION
### Overview
Linked Issue: #33 

### 해결 방법
인증된 가게만 체크 여부와 상관없이 지도 섹션에서 사용되는 가게 데이터는 전체 데이터로 사용되고 있었습니다.
체크시에 지도 섹션에서도 인증된 가게데이터만 사용하도록 수정했습니다.

ScreenShot

https://user-images.githubusercontent.com/7058293/197323519-8ef5aa89-c330-44f1-823b-c0d4c15d3ee2.MP4

