### PR TITLE
[메인 홈 화면] 마지막 가게에서 우측으로 스크롤시 크래시 수정 #38

### DIFF
--- a/3dollar-in-my-pocket/domain/home/HomeReactor.swift
+++ b/3dollar-in-my-pocket/domain/home/HomeReactor.swift
@@ -293,6 +293,7 @@ final class HomeReactor: BaseReactor, Reactor {
             ])
             
         case .selectStore(let index):
+            guard index < self.currentState.storeCellTypes.count else { return .empty() }
             let selectedStoreCell = self.currentState.storeCellTypes[index]
             
             switch selectedStoreCell {


### PR DESCRIPTION
## Overview
Linked Issue: #38 

## 해결 방법
- 스크롤을 범위가 벗어나도록 땡기면 index out of range 에러가 발생했습니다.
- 홈 화면 하단에 셀 개수에 대한 유효성 검사 없이 직접 조회하다보니 생긴 오류였습니다.
- 인덱스 접근 전, 하단 셀 개수에 대한 유효성 검사를 하도록 추가했습니다.

ScreenShot

https://user-images.githubusercontent.com/7058293/198178810-8d31208d-73d7-400c-87c5-1af408ecc469.MP4

