### PR TITLE
푸드트럭 피드백 API URL 변경 #34

### DIFF
--- a/3dollar-in-my-pocket/domain/boss-store-detail/feedback/BossStoreFeedbackReactor.swift
+++ b/3dollar-in-my-pocket/domain/boss-store-detail/feedback/BossStoreFeedbackReactor.swift
@@ -108,6 +108,7 @@ final class BossStoreFeedbackReactor: BaseReactor, Reactor {
         selectedFeedbakcs: [BossStoreFeedbackType]
     ) -> Observable<Mutation> {
         return self.feedbackService.sendFeedbacks(
+            storeType: .foodTruck,
             bossStoreId: bossStoreId,
             feedbackTypes: selectedFeedbakcs
         )
@@ -121,6 +122,7 @@ final class BossStoreFeedbackReactor: BaseReactor, Reactor {
     
     private func fetchFeedbacks(bossStoreId: String) -> Observable<Mutation> {
         return self.feedbackService.fetchBossStoreFeedbacks(
+            storeType: .foodTruck,
             bossStoreId: self.bossStoreId
         )
         .do(onNext: { [weak self] feedbacks in

--- a/3dollar-in-my-pocket/domain/splash/SplashViewModel.swift
+++ b/3dollar-in-my-pocket/domain/splash/SplashViewModel.swift
@@ -129,7 +129,7 @@ final class SplashViewModel: BaseViewModel {
     }
     
     private func fetchBossStoreTypes() {
-        self.feedbackService.fetchFeedbackTypes()
+        self.feedbackService.fetchFeedbackTypes(storeType: .foodTruck)
             .subscribe(onNext: { [weak self] feedbackTypes in
                 self?.metaContext.feedbackTypes = feedbackTypes
             }, onError: { [weak self] error in

--- a/3dollar-in-my-pocket/model/presentation/StoreType.swift
+++ b/3dollar-in-my-pocket/model/presentation/StoreType.swift
@@ -24,6 +24,16 @@ enum StoreType {
         }
     }
     
+    var targetType: String {
+        switch self {
+        case .foodTruck:
+            return "BOSS_STORE"
+            
+        case .streetFood:
+            return "USER_STORE"
+        }
+    }
+    
     func toggle() -> Self {
         switch self {
         case .streetFood:

--- a/3dollar-in-my-pocket/services/FeedbackService.swift
+++ b/3dollar-in-my-pocket/services/FeedbackService.swift
@@ -2,13 +2,15 @@ import Alamofire
 import RxSwift
 
 protocol FeedbackServiceProtocol {
-    func fetchFeedbackTypes() -> Observable<[BossStoreFeedbackMeta]>
+    func fetchFeedbackTypes(storeType: StoreType) -> Observable<[BossStoreFeedbackMeta]>
     
     func fetchBossStoreFeedbacks(
+        storeType: StoreType,
         bossStoreId: String
     ) -> Observable<[BossStoreFeedback]>
     
     func sendFeedbacks(
+        storeType: StoreType,
         bossStoreId: String,
         feedbackTypes: [BossStoreFeedbackType]
     ) -> Observable<Void>
@@ -17,8 +19,8 @@ protocol FeedbackServiceProtocol {
 struct FeedbackService: FeedbackServiceProtocol {
     private let networkManager = NetworkManager()
     
-    func fetchFeedbackTypes() -> Observable<[BossStoreFeedbackMeta]> {
-        let urlString = HTTPUtils.url + "/api/v1/boss/store/feedback/types"
+    func fetchFeedbackTypes(storeType: StoreType) -> Observable<[BossStoreFeedbackMeta]> {
+        let urlString = HTTPUtils.url + "/api/v1/feedback/\(storeType.targetType)/types"
         
         return self.networkManager.createGetObservable(
             class: [BossStoreFeedbackTypeResponse].self,
@@ -29,9 +31,11 @@ struct FeedbackService: FeedbackServiceProtocol {
     }
     
     func fetchBossStoreFeedbacks(
+        storeType: StoreType,
         bossStoreId: String
     ) -> Observable<[BossStoreFeedback]> {
-        let urlString = HTTPUtils.url + "/api/v1/boss/store/\(bossStoreId)/feedbacks/full"
+        let urlString = HTTPUtils.url
+        + "/api/v1/feedback/\(storeType.targetType)/target/\(bossStoreId)/full"
         
         return self.networkManager.createGetObservable(
             class: [BossStoreFeedbackCountWithRatioResponse].self,
@@ -42,10 +46,12 @@ struct FeedbackService: FeedbackServiceProtocol {
     }
     
     func sendFeedbacks(
+        storeType: StoreType,
         bossStoreId: String,
         feedbackTypes: [BossStoreFeedbackType]
     ) -> Observable<Void> {
-        let urlString = HTTPUtils.url + "/api/v1/boss/store/\(bossStoreId)/feedback"
+        let urlString = HTTPUtils.url
+        + "/api/v1/feedback/\(storeType.targetType)/target/\(bossStoreId)"
         let parameters = ["feedbackTypes": feedbackTypes.map { $0.rawValue }]
         
         return .create { observer in


### PR DESCRIPTION
## Overview
Linked Issue: #34 

## 수정 내용
[AS-IS]
- POST /api/v1/boss/store/{bossStoreId}/feedback
- GET /api/v1/boss/store/{bossStoreId}/feedbacks/full
- GET /api/v1/boss/store/feedback/types

[TO-BE]
- POST ​/api​/v1​/feedback​/{targetType}​/target​/{targetId}
- GET /api/v1/feedback/{targetType}/target/{targetId}/full
- GET /api/v1/feedback/{targetType}/types

     
targetType: BOSS_STORE, USER_STORE ...
targetId: 해당 가게의 ID (String)

ScreenShot
- 스크린샷과 무관합니다.