### PR TITLE
[카테고리 화면] 푸드트럭 앱 업데이트 후 카테고리 화면의 광고 슬롯이 사라진 오류 수정. #40

### DIFF
--- a/3dollar-in-my-pocket/domain/category-filter/CategoryFilterViewController.swift
+++ b/3dollar-in-my-pocket/domain/category-filter/CategoryFilterViewController.swift
@@ -132,11 +132,11 @@ final class CategoryFilterViewController: BaseViewController, View, CategoryFilt
                     .map { $0.advertisement }
                     .distinctUntilChanged()
                     .do(onNext: { advertisement in
-                        if advertisement == nil {
-                            if let layout = collectionView.collectionViewLayout
-                                as? UICollectionViewFlowLayout {
-                                layout.headerReferenceSize = .zero
-                            }
+                        if let layout = collectionView.collectionViewLayout
+                            as? UICollectionViewFlowLayout {
+                            layout.headerReferenceSize = advertisement == nil
+                            ? .zero
+                            : CategoryFilterHeaderView.size
                         }
                     })
                     .asDriver(onErrorJustReturn: nil)

--- a/3dollar-in-my-pocket/domain/category-filter/subviews/CategoryFilterHeaderView.swift
+++ b/3dollar-in-my-pocket/domain/category-filter/subviews/CategoryFilterHeaderView.swift
@@ -58,7 +58,7 @@ final class CategoryFilterHeaderView: UICollectionReusableView {
     }
     
     fileprivate func bind(advertisement: Advertisement?) {
-        guard let advertisement = advertisement else { return}
+        guard let advertisement = advertisement else { return }
 
         self.titleLabel.text = advertisement.title
         self.titleLabel.textColor = .init(hex: advertisement.fontColor)


### PR DESCRIPTION
## Overview
Linked Issue: #40 

## 해결 방법
- 광고 조회 API까지 모두 호출하긴 하지만.. 화면상 노출 영역을 잡아주지 않아서 보이지 않았습니다.
- 화면 영역을 잡아주었습니다.

## ScreenShot

https://user-images.githubusercontent.com/7058293/198292193-61b9f426-fddb-4b2d-b5aa-2d071335e2c0.MP4


