### PR TITLE
제보하기 탭 생성 #45

### DIFF
--- a/3dollar-in-my-pocket/context/GlobalState.swift
+++ b/3dollar-in-my-pocket/context/GlobalState.swift
@@ -22,4 +22,7 @@ final class GlobalState {
     
     /// 길거리 음식점 리뷰를 남긴 경우
     let addStoreReview = PublishSubject<Review>()
+    
+    /// 가게 제보를 완료한 경우
+    let addStore = PublishSubject<Store>()
 }

--- a/3dollar-in-my-pocket/domain/food-truck-list/FoodTruckListViewController.swift
+++ b/3dollar-in-my-pocket/domain/food-truck-list/FoodTruckListViewController.swift
@@ -22,7 +22,7 @@ final class FoodTruckListViewController: BaseViewController, View, FoodTruckList
     static func instance() -> UINavigationController {
         let viewController = FoodTruckListViewController(nibName: nil, bundle: nil).then {
             $0.tabBarItem = UITabBarItem(
-                title: nil,
+                title: R.string.localization.tab_food_truck(),
                 image: UIImage(named: "ic_food_truck"),
                 tag: TabBarTag.foodTruck.rawValue
             )

--- a/3dollar-in-my-pocket/domain/home/HomeReactor.swift
+++ b/3dollar-in-my-pocket/domain/home/HomeReactor.swift
@@ -28,6 +28,7 @@ final class HomeReactor: BaseReactor, Reactor {
     enum Mutation {
         case shownTooltip
         case setStoreType(StoreType)
+        case addStreetStore(Store)
         case setStoreCellTypes([StoreCellType])
         case setCategories([Categorizable])
         case setCurrentLocation(CLLocation)
@@ -428,7 +429,9 @@ final class HomeReactor: BaseReactor, Reactor {
         return .merge([
             mutation,
             self.globalState.updateStore
-                .map { .updateStore(store: $0) }
+                .map { .updateStore(store: $0) },
+            self.globalState.addStore
+                .map { .addStreetStore($0) }
         ])
     }
     
@@ -442,6 +445,11 @@ final class HomeReactor: BaseReactor, Reactor {
             
         case .setTooltipHidden(let isHidden):
             newState.isTooltipHidden = isHidden
+            
+        case .addStreetStore(let store):
+            if newState.storeType == .streetFood {
+                newState.storeCellTypes.insert(.store(store), at: 0)
+            }
             
         case .setStoreType(let storeType):
             newState.storeType = storeType

--- a/3dollar-in-my-pocket/domain/home/HomeViewController.swift
+++ b/3dollar-in-my-pocket/domain/home/HomeViewController.swift
@@ -26,7 +26,7 @@ final class HomeViewController: BaseViewController, View, HomeCoordinator {
     static func instance() -> UINavigationController {
         let viewController = HomeViewController(nibName: nil, bundle: nil).then {
             $0.tabBarItem = UITabBarItem(
-                title: nil,
+                title: R.string.localization.tab_home(),
                 image: R.image.ic_home(),
                 tag: TabBarTag.home.rawValue
             )

--- a/3dollar-in-my-pocket/domain/main/TabBarVC.swift
+++ b/3dollar-in-my-pocket/domain/main/TabBarVC.swift
@@ -25,6 +25,7 @@ class TabBarVC: UITabBarController {
         self.setupTabBarController()
         self.addKakaoLinkObserver()
         self.feedbackGenerator.prepare()
+        self.delegate = self
         if #available(iOS 15, *) {
             let appearance = UITabBarAppearance()
             appearance.configureWithOpaqueBackground()
@@ -32,6 +33,10 @@ class TabBarVC: UITabBarController {
             self.tabBar.standardAppearance = appearance
             self.tabBar.scrollEdgeAppearance = appearance
         }
+        UITabBarItem.appearance().setTitleTextAttributes(
+            [.font: UIFont.bold(size: 10) as Any],
+            for: .normal
+        )
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -106,6 +111,7 @@ class TabBarVC: UITabBarController {
         self.setViewControllers([
             HomeViewController.instance(),
             StreetFoodListViewController.instance(),
+            WriteAddressViewController.instance(delegate: self),
             FoodTruckListViewController.instance(),
             MyPageViewController.instance()
         ], animated: true)
@@ -183,5 +189,34 @@ class TabBarVC: UITabBarController {
                     }
                 })
             .disposed(by: self.disposeBag)
+    }
+}
+
+extension TabBarVC: WriteAddressDelegate {
+    func onWriteSuccess(storeId: Int) {
+        self.selectedIndex = 0
+        if let navigationViewController = self.viewControllers?[0] as? UINavigationController,
+           let homeViewController
+            = navigationViewController.viewControllers[0] as? HomeViewController {
+            navigationViewController.popToRootViewController(animated: false)
+            homeViewController.coordinator?.pushStoreDetail(storeId: String(storeId))
+        }
+    }
+}
+
+extension TabBarVC: UITabBarControllerDelegate {
+    func tabBarController(
+        _ tabBarController: UITabBarController,
+        shouldSelect viewController: UIViewController
+    ) -> Bool {
+        if let navigationViewController = viewController as? UINavigationController {
+            if navigationViewController.topViewController is WriteAddressViewController {
+                let writeVC = WriteAddressViewController.instance(delegate: self)
+                
+                self.present(writeVC, animated: true, completion: nil)
+                return false
+            }
+        }
+        return true
     }
 }

--- a/3dollar-in-my-pocket/domain/my-page/MyPageViewController.swift
+++ b/3dollar-in-my-pocket/domain/my-page/MyPageViewController.swift
@@ -17,7 +17,7 @@ final class MyPageViewController: BaseVC, MyPageCoordinator {
     static func instance() -> UINavigationController {
         let viewController = MyPageViewController(nibName: nil, bundle: nil).then {
             $0.tabBarItem = UITabBarItem(
-                title: nil,
+                title: R.string.localization.tab_my(),
                 image: R.image.ic_my(),
                 tag: TabBarTag.my.rawValue
             )

--- a/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListCoordinator.swift
+++ b/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListCoordinator.swift
@@ -4,8 +4,6 @@ protocol StreetFoodListCoordinator: BaseCoordinator, AnyObject {
     func presentCategoryFilter()
     
     func pushStoreDetail(storeId: Int)
-    
-    func presentWriteAddress()
 }
 
 extension StreetFoodListCoordinator where Self: StreetFoodListViewController {
@@ -19,11 +17,5 @@ extension StreetFoodListCoordinator where Self: StreetFoodListViewController {
         let viewController = StoreDetailViewController.instance(storeId: storeId)
         
         self.presenter.navigationController?.pushViewController(viewController, animated: true)
-    }
-    
-    func presentWriteAddress() {
-        let viewController = WriteAddressViewController.instance(delegate: self)
-        
-        self.tabBarController?.present(viewController, animated: true)
     }
 }

--- a/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListView.swift
+++ b/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListView.swift
@@ -87,13 +87,6 @@ final class StreetFoodListView: Base.BaseView {
             withReuseIdentifier: StreetFoodListHeaderView.registerId
         )
     }
-    
-    let writeButton = UIButton().then {
-        $0.layer.cornerRadius = 25
-        $0.backgroundColor = R.color.red()
-        $0.setImage(R.image.ic_write(), for: .normal)
-        $0.contentEdgeInsets = .init(top: 14, left: 14, bottom: 14, right: 14)
-    }
         
     override func setup() {
         self.backgroundColor = R.color.gray0()
@@ -102,11 +95,8 @@ final class StreetFoodListView: Base.BaseView {
             self.topContainerView,
             self.categoryImageView,
             self.categoryLabel,
-            self.categoryButton,
-            self.writeButton
+            self.categoryButton
         ])
-        
-        self.collectionView.delegate = self
     }
     
     override func bindConstraints() {
@@ -141,32 +131,11 @@ final class StreetFoodListView: Base.BaseView {
             make.top.equalTo(self.topContainerView.snp.bottom).offset(-20)
             make.bottom.equalTo(self.safeAreaLayoutGuide)
         }
-        
-        self.writeButton.snp.makeConstraints { make in
-            make.right.equalToSuperview().offset(-24)
-            make.bottom.equalTo(self.safeAreaLayoutGuide).offset(-24)
-            make.width.equalTo(50)
-            make.height.equalTo(50)
-        }
     }
     
     fileprivate func bind(category: StreetFoodCategory) {
         self.categoryImageView.setImage(urlString: category.imageUrl)
         self.categoryLabel.text = category.name
-    }
-    
-    private func showWriteAddressButton() {
-        UIView.transition(with: self, duration: 0.3, options: .curveEaseInOut) { [weak self] in
-            self?.writeButton.transform = .identity
-            self?.writeButton.alpha = 1
-        }
-    }
-    
-    private func hideWriteAddressButton() {
-        UIView.transition(with: self, duration: 0.3, options: .curveEaseInOut) { [weak self] in
-            self?.writeButton.transform = .init(translationX: 0, y: 100)
-            self?.writeButton.alpha = 0
-        }
     }
 }
 
@@ -175,15 +144,5 @@ extension Reactive where Base: StreetFoodListView {
         return Binder(self.base) { view, category in
             view.bind(category: category)
         }
-    }
-}
-
-extension StreetFoodListView: UICollectionViewDelegate {
-    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        self.hideWriteAddressButton()
-    }
-    
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        self.showWriteAddressButton()
     }
 }

--- a/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListViewController.swift
+++ b/3dollar-in-my-pocket/domain/street-food-list/StreetFoodListViewController.swift
@@ -22,7 +22,7 @@ final class StreetFoodListViewController: BaseViewController, StreetFoodListCoor
     static func instance() -> UINavigationController {
         let viewController = StreetFoodListViewController(nibName: nil, bundle: nil).then {
             $0.tabBarItem = UITabBarItem(
-                title: nil,
+                title: R.string.localization.tab_street_food(),
                 image: UIImage(named: "ic_street_food"),
                 tag: TabBarTag.streetFood.rawValue
             )
@@ -57,14 +57,6 @@ final class StreetFoodListViewController: BaseViewController, StreetFoodListCoor
     }
   
     override func bindEvent() {
-        self.streetFoodListView.writeButton.rx.tap
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .asDriver(onErrorJustReturn: ())
-            .drive(onNext: { [weak self] _ in
-                self?.coordinator?.presentWriteAddress()
-            })
-            .disposed(by: self.eventDisposeBag)
-        
         self.streetFoodListReactor.pushStoreDetailPublisher
             .asDriver(onErrorJustReturn: -1)
             .drive(onNext: { [weak self] storeId in
@@ -248,11 +240,5 @@ extension StreetFoodListViewController: NMFMapViewCameraDelegate {
                 self.streetFoodListReactor.action.onNext(.changeMapLocation(mapLocation))
             }
         }
-    }
-}
-
-extension StreetFoodListViewController: WriteAddressDelegate {
-    func onWriteSuccess(storeId: Int) {
-        self.coordinator?.pushStoreDetail(storeId: storeId)
     }
 }

--- a/3dollar-in-my-pocket/domain/writing/write-address/WriteAddressViewController.swift
+++ b/3dollar-in-my-pocket/domain/writing/write-address/WriteAddressViewController.swift
@@ -22,6 +22,11 @@ final class WriteAddressViewController: BaseVC, View, WriteAddressCoordinator {
     static func instance(delegate: WriteAddressDelegate) -> UINavigationController {
         let writeAddressVC = WriteAddressViewController(nibName: nil, bundle: nil).then {
             $0.delegate = delegate
+            $0.tabBarItem = UITabBarItem(
+                title: R.string.localization.tab_write(),
+                image: R.image.ic_write(),
+                tag: TabBarTag.write.rawValue
+            )
         }
         
         return UINavigationController(rootViewController: writeAddressVC).then {

--- a/3dollar-in-my-pocket/domain/writing/write-detail/WriteDetailVC.swift
+++ b/3dollar-in-my-pocket/domain/writing/write-detail/WriteDetailVC.swift
@@ -21,7 +21,8 @@ class WriteDetailVC: BaseVC {
     self.viewModel = WriteDetailViewModel(
       address: address,
       location: location,
-      storeService: StoreService()
+      storeService: StoreService(),
+      globalState: GlobalState.shared
     )
     super.init(nibName: nil, bundle: nil)
   }

--- a/3dollar-in-my-pocket/domain/writing/write-detail/WriteDetailViewModel.swift
+++ b/3dollar-in-my-pocket/domain/writing/write-detail/WriteDetailViewModel.swift
@@ -9,6 +9,7 @@ class WriteDetailViewModel: BaseViewModel {
   let output = Output()
   
   let storeService: StoreServiceProtocol
+  let globalState: GlobalState
   let address: String
   let location: (Double, Double)
   var appearenceDay: [WeekDay] = []
@@ -49,11 +50,13 @@ class WriteDetailViewModel: BaseViewModel {
   init(
     address: String,
     location: (Double, Double),
-    storeService: StoreServiceProtocol
+    storeService: StoreServiceProtocol,
+    globalState: GlobalState
   ) {
     self.address = address
     self.location = location
     self.storeService = storeService
+    self.globalState = globalState
     super.init()
     
     self.input.storeName
@@ -235,6 +238,7 @@ class WriteDetailViewModel: BaseViewModel {
         onNext: { [weak self] store in
           guard let self = self else { return }
           
+          self.globalState.addStore.onNext(store)
           self.output.dismissAndGoDetail.accept(store.storeId)
           self.output.showLoading.accept(false)
         },

--- a/3dollar-in-my-pocket/model/TabBarTag.swift
+++ b/3dollar-in-my-pocket/model/TabBarTag.swift
@@ -1,6 +1,7 @@
 enum TabBarTag: Int {
     case home
     case streetFood
+    case write
     case foodTruck
     case my
 }

--- a/3dollar-in-my-pocket/resource/en.lproj/Localization.strings
+++ b/3dollar-in-my-pocket/resource/en.lproj/Localization.strings
@@ -21,6 +21,11 @@
 "error_location_default_message" = "위치 오류가 발생되었습니다.\n에러가 개발자에게 보고됩니다.";
 "splash_need_update_title" = "업데이트 필요";
 "splash_need_update_description" = "따끈따끈한 업데이트가 나왔어요!\n확인버튼을 눌러 업데이트를 진행해주세요!";
+"tab_home" = "홈";
+"tab_street_food" = "길거리음식";
+"tab_write" = "제보하기";
+"tab_food_truck" = "푸드트럭";
+"tab_my" = "MY";
 "setting_title" = "설정";
 "setting_nickname_modify" = "닉네임 수정";
 "setting_menu_question" = "문의사항";

--- a/3dollar-in-my-pocket/resource/ko.lproj/Localization.strings
+++ b/3dollar-in-my-pocket/resource/ko.lproj/Localization.strings
@@ -21,6 +21,11 @@
 "error_location_default_message" = "위치 오류가 발생되었습니다.\n에러가 개발자에게 보고됩니다.";
 "splash_need_update_title" = "업데이트 필요";
 "splash_need_update_description" = "따끈따끈한 업데이트가 나왔어요!\n확인버튼을 눌러 업데이트를 진행해주세요!";
+"tab_home" = "홈";
+"tab_street_food" = "길거리음식";
+"tab_write" = "제보하기";
+"tab_food_truck" = "푸드트럭";
+"tab_my" = "MY";
 "setting_title" = "설정";
 "setting_nickname_modify" = "닉네임 수정";
 "setting_menu_question" = "문의사항";

--- a/3dollar-in-my-pocket/script/string_resource.py
+++ b/3dollar-in-my-pocket/script/string_resource.py
@@ -77,14 +77,17 @@ def get_strings_from_csv(savepath, file_name):
 def write_strings(string_list, save_path):
     if not os.path.exists(save_path + "/resource/en.lproj/"):
         os.makedirs(save_path + "/resource/en.lproj/")
+        os.makedirs(save_path + "/resource/ko.lproj/")
 
-    string_file = open(save_path + "/resource/en.lproj/Localization.strings", "w")
+    en_string_file = open(save_path + "/resource/en.lproj/Localization.strings", "w")
+    ko_string_file = open(save_path + "/resource/ko.lproj/Localization.strings", "w")
 
     for item in string_list:
-        string_file.write("\"" + item["key"] + "\" = \"" + item["ko"] + "\";\n")
+        en_string_file.write("\"" + item["key"] + "\" = \"" + item["ko"] + "\";\n")
+        ko_string_file.write("\"" + item["key"] + "\" = \"" + item["ko"] + "\";\n")
 
-    string_file.close()
-
+    en_string_file.close()
+    ko_string_file.close()
 
 if __name__ == '__main__':
     get_gdoc_information()


### PR DESCRIPTION
## 변경사항
- 길거리음식 탭에 있던 제보하기 버튼을 가운데 탭으로 이동할 수 있도록 변경합니다.

## 배경
- 제보하기 버튼이 탭에 있다가 푸드트럭 피처가 진행되며 길거리음색 탭으로 이동했으나, 사용자들이 제보하기 버튼이 어디로 갔는지 혼란스러워 하여 다시 탭으로 내립니다.
- 레이블도 같이 붙여서 접근성을 쉽게 하였습니다.

## Screenshot

https://user-images.githubusercontent.com/7058293/199905392-6190e89e-4823-4e83-a3b5-9eb282f6edb6.MP4

