### PR TITLE
[유저앱/ 마커 모달 화면] 이미지 마스킹이 적용되어있지 않는 오류 수정

### DIFF
--- a/3dollar-in-my-pocket/domain/home/marker-popup/MarkerPopupView.swift
+++ b/3dollar-in-my-pocket/domain/home/marker-popup/MarkerPopupView.swift
@@ -9,6 +9,7 @@ final class MarkerPopupView: BaseView {
     private let containerView = UIView().then {
         $0.layer.cornerRadius = 30
         $0.backgroundColor = .white
+        $0.layer.masksToBounds = true
     }
     
     private let imageView = UIImageView().then {


### PR DESCRIPTION
## Overview
Linked Issue: #57 

## 해결 방법
- 마커 모달의 ImageView에 `layer.maskToBounds` 적용했습니다.

## ScreenShot

![IMG_144CFFB781E0-1](https://user-images.githubusercontent.com/7058293/208811744-b38f362d-6fb5-486e-ae0a-c53bebc5f29f.jpeg)