### PR TITLE
fix: [마수동] 기존 가입자들 마수동 받을 때, 디바이스 동록 API 호출하도록 수정 #54

### DIFF
--- a/3dollar-in-my-pocket/design-system/color/Color.swift
+++ b/3dollar-in-my-pocket/design-system/color/Color.swift
@@ -33,7 +33,7 @@ struct Color {
     
     static let green = UIColor(named: "green")
     
-    static let kakaoYellow = UIColor(named: "kakaoYellow")
+    static let kakaoYellow = UIColor(named: "kakao-yellow")
     
     static let pink = UIColor(named: "pink")
     

--- a/3dollar-in-my-pocket/domain/membership/NicknameViewController.swift
+++ b/3dollar-in-my-pocket/domain/membership/NicknameViewController.swift
@@ -10,8 +10,7 @@ class NicknameViewController: BaseVC {
     self.viewModel = NicknameViewModel(
       signinRequest: signinRequest,
       userDefaults: UserDefaultsUtil(),
-      userService: UserService(),
-      deviceService: DeviceService()
+      userService: UserService()
     )
     super.init(nibName: nil, bundle: nil)
   }

--- a/3dollar-in-my-pocket/domain/membership/NicknameViewModel.swift
+++ b/3dollar-in-my-pocket/domain/membership/NicknameViewModel.swift
@@ -18,20 +18,17 @@ class NicknameViewModel: BaseViewModel {
   let signinRequest: SigninRequest
   var userDefaults: UserDefaultsUtil
   let userService: UserServiceProtocol
-    private let deviceService: DeviceServiceProtocol
     var isSignupSuccess = false
   
   
   init(
     signinRequest: SigninRequest,
     userDefaults: UserDefaultsUtil,
-    userService: UserServiceProtocol,
-    deviceService: DeviceServiceProtocol
+    userService: UserServiceProtocol
   ) {
     self.signinRequest = signinRequest
     self.userDefaults = userDefaults
     self.userService = userService
-      self.deviceService = deviceService
     super.init()
     
     self.input.nickname
@@ -59,22 +56,12 @@ class NicknameViewModel: BaseViewModel {
                 .subscribe(
                     onNext: { [weak self] response in
                         guard let self = self else { return }
+                        
                         self.userDefaults.userId = response.userId
                         self.userDefaults.authToken = response.token
                         self.isSignupSuccess = true
-
-                        self.deviceService.getFCMToken()
-                            .flatMap { pushToken -> Observable<String> in
-                                return self.deviceService.registerDevice(
-                                    pushPlatformType: .fcm,
-                                    pushToken: pushToken
-                                )
-                            }
-                            .subscribe { _ in
-                                self.showLoading.accept(false)
-                                self.output.presentPolicy.accept(())
-                            }
-                            .disposed(by: self.disposeBag)
+                        self.showLoading.accept(false)
+                        self.output.presentPolicy.accept(())
                     },
                     onError: self.handleSignupError(error:)
                 )

--- a/3dollar-in-my-pocket/domain/membership/policy/PolicyViewController.swift
+++ b/3dollar-in-my-pocket/domain/membership/policy/PolicyViewController.swift
@@ -10,6 +10,7 @@ final class PolicyViewController: BaseViewController, View, PolicyCoordinator {
     private let policyView = PolicyView()
     private let policyReactor = PolicyReactor(
         userService: UserService(),
+        deviceService: DeviceService(),
         analyticsManager: AnalyticsManager.shared
     )
     private weak var coordinator: PolicyCoordinator?


### PR DESCRIPTION
## Overview
Linked Issue: #54 

## 해결 방법
- 마수동 팝업 확인 버튼 터치 시, 디바이스 토큰 등록 과 마수동 상태 저장 두가지 API 같이 호출하도록 수정했습니다.
- 기존에 신규가입 유저를 위해 닉네임 설정화면에서도 디바이스 토큰 등록 API를 호출했는데, 삭제했습니다.
  - 마수동 팝업에서 디바이스 토큰 등록 API 호출하기 떄문에 중복입니다.

## ScreenShot
- 스크린샷과 무관합니다.