### PR TITLE
[즐겨찾기 리스트 화면] 공유하기 버튼 및 기능 추가 #70

### DIFF
--- a/3dollar-in-my-pocket.xcodeproj/project.pbxproj
+++ b/3dollar-in-my-pocket.xcodeproj/project.pbxproj
@@ -3717,6 +3717,7 @@
 				API_URL = "https://dev.threedollars.co.kr";
 				APP_DISPLAY_NAME = "가슴속3천원-Dev";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BOOKMARK_URL = "https://3dollarsdev.page.link/bookmark";
 				CODE_SIGN_ENTITLEMENTS = "3dollar-in-my-pocket/3dollar-in-my-pocket.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -3764,6 +3765,7 @@
 				API_URL = "https://threedollars.co.kr";
 				APP_DISPLAY_NAME = "가슴속3천원";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BOOKMARK_URL = "https://3dollars.page.link/bookmark";
 				CODE_SIGN_ENTITLEMENTS = "3dollar-in-my-pocket/3dollar-in-my-pocket.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/3dollar-in-my-pocket.xcodeproj/xcshareddata/xcschemes/3dollar-in-my-pocket.xcscheme
+++ b/3dollar-in-my-pocket.xcodeproj/xcshareddata/xcschemes/3dollar-in-my-pocket.xcscheme
@@ -38,16 +38,6 @@
                ReferencedContainer = "container:3dollar-in-my-pocket.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6E0EA3B323ABB232008F7CB2"
-               BuildableName = "3dollar-in-my-pocketUITests.xctest"
-               BlueprintName = "3dollar-in-my-pocketUITests"
-               ReferencedContainer = "container:3dollar-in-my-pocket.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/3dollar-in-my-pocket/3dollar-in-my-pocket.entitlements
+++ b/3dollar-in-my-pocket/3dollar-in-my-pocket.entitlements
@@ -8,5 +8,10 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:3dollarsdev.page.link</string>
+		<string>applinks:3dollars.page.link</string>
+	</array>
 </dict>
 </plist>

--- a/3dollar-in-my-pocket/Info.plist
+++ b/3dollar-in-my-pocket/Info.plist
@@ -2,12 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>URL_PRIVACY</key>
-	<string>$(URL_PRIVACY)</string>
-	<key>URL_MARKETING</key>
-	<string>$(URL_MARKETING)</string>
-	<key>URL_POLICY</key>
-	<string>$(URL_POLICY)</string>
+	<key>BOOKMARK_URL</key>
+	<string>$(BOOKMARK_URL)</string>
 	<key>ADMOB_UNIT_ID</key>
 	<string>$(ADMOB_UNIT_ID)</string>
 	<key>API_URL</key>
@@ -62,6 +58,16 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>kakao95f91f9656806e132796f0071ab99aaa</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>dynamiclink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			</array>
 		</dict>
 	</array>
@@ -152,5 +158,11 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>URL_MARKETING</key>
+	<string>$(URL_MARKETING)</string>
+	<key>URL_POLICY</key>
+	<string>$(URL_POLICY)</string>
+	<key>URL_PRIVACY</key>
+	<string>$(URL_PRIVACY)</string>
 </dict>
 </plist>

--- a/3dollar-in-my-pocket/domain/my-page/bookmark-list/BookmarkListCoordinator.swift
+++ b/3dollar-in-my-pocket/domain/my-page/bookmark-list/BookmarkListCoordinator.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 protocol BookmarkListCoordinator: BaseCoordinator, AnyObject {
     func pushStoreDetail(storeId: String)
     
@@ -6,6 +8,8 @@ protocol BookmarkListCoordinator: BaseCoordinator, AnyObject {
     func showDeleteAllPopup()
     
     func pushEditBookmarkFolder(bookmarkFolder: BookmarkFolder)
+    
+    func presentSharePannel(url: String)
 }
 
 extension BookmarkListCoordinator {
@@ -33,5 +37,15 @@ extension BookmarkListCoordinator {
         let viewController = BookmarkEditViewController.instance(bookmarkFolder: bookmarkFolder)
         
         self.presenter.navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    func presentSharePannel(url: String) {
+        let viewController = UIActivityViewController(
+            activityItems : [url],
+            applicationActivities: nil
+        )
+        
+        viewController.popoverPresentationController?.sourceView = self.presenter.view
+        self.presenter.present(viewController, animated: true, completion: nil)
     }
 }

--- a/3dollar-in-my-pocket/domain/my-page/bookmark-list/BookmarkListReactor.swift
+++ b/3dollar-in-my-pocket/domain/my-page/bookmark-list/BookmarkListReactor.swift
@@ -6,6 +6,7 @@ final class BookmarkListReactor: BaseReactor, Reactor {
     enum Action {
         case viewDidLoad
         case willDisplayCell(row: Int)
+        case tapShare
         case tapEditOverview
         case tapDeleteMode
         case tapDeleteAll
@@ -22,6 +23,7 @@ final class BookmarkListReactor: BaseReactor, Reactor {
         case toggleDeleteMode
         case pushEditBookmarkFolder
         case clearBookmakrs
+        case presentSharePannel(bookmarkURL: String)
         case deleteBookamrk(storeId: String)
         case pushStoreDetail(storeId: String)
         case pushFoodTruckDetail(storeId: String)
@@ -34,6 +36,7 @@ final class BookmarkListReactor: BaseReactor, Reactor {
         var totalCount: Int?
         var isDeleteMode: Bool
         var userName: String
+        @Pulse var presentSharePannel: String?
         @Pulse var pushStoreDetail: String?
         @Pulse var pushFoodtruckDetail: String?
         @Pulse var pushEditBookmarkFolder: BookmarkFolder?
@@ -79,6 +82,9 @@ final class BookmarkListReactor: BaseReactor, Reactor {
             guard self.canFetchNextPage(row: row) else { return .empty() }
             
             return self.fetchBookmarks()
+            
+        case .tapShare:
+            return self.createBookmarkURL()
             
         case .tapEditOverview:
             return .just(.pushEditBookmarkFolder)
@@ -161,6 +167,9 @@ final class BookmarkListReactor: BaseReactor, Reactor {
         case .clearBookmakrs:
             newState.bookmarkFolder.bookmarks = []
             
+        case .presentSharePannel(let bookmarkURL):
+            newState.presentSharePannel = bookmarkURL
+            
         case .deleteBookamrk(let storeId):
             if let targetIndex = newState.bookmarkFolder.bookmarks.firstIndex(where: {
                 $0.id == storeId
@@ -233,6 +242,14 @@ final class BookmarkListReactor: BaseReactor, Reactor {
                     .just(.toggleDeleteMode)
                 ])
             }
+            .catch { .just(.showErrorAlert($0)) }
+    }
+    
+    private func createBookmarkURL() -> Observable<Mutation> {
+        guard let folderId = self.currentState.bookmarkFolder.folderId else { return .empty() }
+        
+        return self.bookmarkService.createBookmarkURL(folderId: folderId)
+            .map { .presentSharePannel(bookmarkURL: $0) }
             .catch { .just(.showErrorAlert($0)) }
     }
 }

--- a/3dollar-in-my-pocket/domain/my-page/bookmark-list/BookmarkListView.swift
+++ b/3dollar-in-my-pocket/domain/my-page/bookmark-list/BookmarkListView.swift
@@ -19,6 +19,14 @@ final class BookmarkListView: BaseView {
         $0.textColor = .white
     }
     
+    let shareButton = UIButton().then {
+        $0.setImage(
+            UIImage(named: "ic_share")?.withRenderingMode(.alwaysTemplate),
+            for: .normal
+        )
+        $0.tintColor = Color.pink
+    }
+    
     let collectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: UICollectionViewLayout()
@@ -49,6 +57,7 @@ final class BookmarkListView: BaseView {
             self.topBackgroundView,
             self.backButton,
             self.titleLabel,
+            self.shareButton,
             self.collectionView
         ])
         self.setCompositionalLayout()
@@ -85,6 +94,13 @@ final class BookmarkListView: BaseView {
         self.titleLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.centerY.equalTo(self.backButton)
+        }
+        
+        self.shareButton.snp.makeConstraints { make in
+            make.right.equalToSuperview().offset(-24)
+            make.centerY.equalTo(self.backButton)
+            make.width.equalTo(24)
+            make.height.equalTo(24)
         }
         
         self.collectionView.snp.makeConstraints { make in

--- a/3dollar-in-my-pocket/extension/BundleExtension.swift
+++ b/3dollar-in-my-pocket/extension/BundleExtension.swift
@@ -16,4 +16,12 @@ extension Bundle {
     static var privacyURL: String {
         return Bundle.main.infoDictionary?["URL_PRIVACY"] as? String ?? ""
     }
+    
+    static var bookmarkURL: String {
+        return Bundle.main.infoDictionary?["BOOKMARK_URL"] as? String ?? ""
+    }
+    
+    static var bundleId: String {
+        return Bundle.main.infoDictionary?["Bundle identifier"] as? String ?? ""
+    }
 }


### PR DESCRIPTION
## Overview
Linked Issue: #70 

## 해결 방법
- 즐겨찾기 리스트 화면의 우측상단에 공유하기 버튼 추가 했습니다.
  - 즐겨찾기 리스트가 있으면 노출되고, 없으면 사라집니다.
- 공유하기 버튼 터치 시, Firebase DynimicLink를 생성합니다.

## ScreenShot

https://user-images.githubusercontent.com/7058293/210042775-b401d5da-406c-420e-af60-f934968f8d0d.mov


