### PR TITLE
#67 [즐겨찾기 뷰어 화면] 서비스 구현

### DIFF
--- a/3dollar-in-my-pocket.xcodeproj/project.pbxproj
+++ b/3dollar-in-my-pocket.xcodeproj/project.pbxproj
@@ -102,6 +102,12 @@
 		6E3AA4DB25AD6C5400D8C58C /* Addition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3AA4DA25AD6C5400D8C58C /* Addition.swift */; };
 		6E3AA4E025AD6C9B00D8C58C /* Region.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3AA4DF25AD6C9B00D8C58C /* Region.swift */; };
 		6E3AA4E525AD6CC300D8C58C /* Area.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3AA4E425AD6CC300D8C58C /* Area.swift */; };
+		6E3BFD892985073400563160 /* DeeplinkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3BFD882985073400563160 /* DeeplinkType.swift */; };
+		6E3BFD8C29850BAB00563160 /* BookmarkViewerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3BFD8B29850BAB00563160 /* BookmarkViewerViewController.swift */; };
+		6E3BFD90298510F500563160 /* BookmarkViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3BFD8F298510F500563160 /* BookmarkViewerView.swift */; };
+		6E3BFD93298521C600563160 /* BookmarkViewerHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3BFD92298521C600563160 /* BookmarkViewerHeaderView.swift */; };
+		6E3BFD952985270900563160 /* BookmarkViewerStoreCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3BFD942985270900563160 /* BookmarkViewerStoreCollectionViewCell.swift */; };
+		6E3BFD972985272D00563160 /* UICollectionViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3BFD962985272D00563160 /* UICollectionViewExtension.swift */; };
 		6E3C1FA526A514F0009939B5 /* VersionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3C1FA426A514F0009939B5 /* VersionUtils.swift */; };
 		6E3DED7725C7E391000BE04C /* RegisterPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3DED7625C7E391000BE04C /* RegisterPhotoView.swift */; };
 		6E3DED7925C7EA32000BE04C /* RegisterPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3DED7825C7EA32000BE04C /* RegisterPhotoViewController.swift */; };
@@ -674,6 +680,12 @@
 		6E3AA4DA25AD6C5400D8C58C /* Addition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Addition.swift; sourceTree = "<group>"; };
 		6E3AA4DF25AD6C9B00D8C58C /* Region.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Region.swift; sourceTree = "<group>"; };
 		6E3AA4E425AD6CC300D8C58C /* Area.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Area.swift; sourceTree = "<group>"; };
+		6E3BFD882985073400563160 /* DeeplinkType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkType.swift; sourceTree = "<group>"; };
+		6E3BFD8B29850BAB00563160 /* BookmarkViewerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkViewerViewController.swift; sourceTree = "<group>"; };
+		6E3BFD8F298510F500563160 /* BookmarkViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkViewerView.swift; sourceTree = "<group>"; };
+		6E3BFD92298521C600563160 /* BookmarkViewerHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkViewerHeaderView.swift; sourceTree = "<group>"; };
+		6E3BFD942985270900563160 /* BookmarkViewerStoreCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkViewerStoreCollectionViewCell.swift; sourceTree = "<group>"; };
+		6E3BFD962985272D00563160 /* UICollectionViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtension.swift; sourceTree = "<group>"; };
 		6E3C1FA426A514F0009939B5 /* VersionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionUtils.swift; sourceTree = "<group>"; };
 		6E3DED7625C7E391000BE04C /* RegisterPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPhotoView.swift; sourceTree = "<group>"; };
 		6E3DED7825C7EA32000BE04C /* RegisterPhotoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPhotoViewController.swift; sourceTree = "<group>"; };
@@ -1448,6 +1460,25 @@
 			path = map;
 			sourceTree = "<group>";
 		};
+		6E3BFD8A29850B9800563160 /* bookmark-viewer */ = {
+			isa = PBXGroup;
+			children = (
+				6E3BFD912985216000563160 /* cell */,
+				6E3BFD8B29850BAB00563160 /* BookmarkViewerViewController.swift */,
+				6E3BFD8F298510F500563160 /* BookmarkViewerView.swift */,
+			);
+			path = "bookmark-viewer";
+			sourceTree = "<group>";
+		};
+		6E3BFD912985216000563160 /* cell */ = {
+			isa = PBXGroup;
+			children = (
+				6E3BFD92298521C600563160 /* BookmarkViewerHeaderView.swift */,
+				6E3BFD942985270900563160 /* BookmarkViewerStoreCollectionViewCell.swift */,
+			);
+			path = cell;
+			sourceTree = "<group>";
+		};
 		6E3DED7525C7E366000BE04C /* register-photo */ = {
 			isa = PBXGroup;
 			children = (
@@ -1795,6 +1826,7 @@
 		6E6B0ED923AD169B006E11CE /* domain */ = {
 			isa = PBXGroup;
 			children = (
+				6E3BFD8A29850B9800563160 /* bookmark-viewer */,
 				6E5938FE2573E2AA00593DC8 /* webview */,
 				6E09A75628B22F6600792F12 /* food-truck-list */,
 				6E7BF37C28A9250A00A00BF2 /* street-food-list */,
@@ -1845,6 +1877,7 @@
 				6E3960EF25F0AF3C004D4644 /* UILabelExtension.swift */,
 				6E451BDC26DD0F870056CDC4 /* UITableViewExtension.swift */,
 				6E6B0EE023AD17AC006E11CE /* UIViewExtension.swift */,
+				6E3BFD962985272D00563160 /* UICollectionViewExtension.swift */,
 			);
 			path = extension;
 			sourceTree = "<group>";
@@ -2129,6 +2162,7 @@
 			children = (
 				6E7E5F5829814D24003747FC /* DeeplinkManager.swift */,
 				6E7E5F5B29815AE5003747FC /* Deeplink.swift */,
+				6E3BFD882985073400563160 /* DeeplinkType.swift */,
 			);
 			path = deeplink;
 			sourceTree = "<group>";
@@ -3079,6 +3113,7 @@
 				6E9BE84C294AB73A0087FC6D /* MarkerPopupViewController.swift in Sources */,
 				6EDD7F1F295A70AB00A5325B /* MyMedalSectionModel.swift in Sources */,
 				6E841F0B294837C100956BBD /* BookmarkEmptyCollectionViewCell.swift in Sources */,
+				6E3BFD93298521C600563160 /* BookmarkViewerHeaderView.swift in Sources */,
 				6E09A75D28B2305F00792F12 /* FoodTruckListHeaderView.swift in Sources */,
 				6E31577925BA9F180022D6F3 /* StorePhotoCollectionViewCell.swift in Sources */,
 				6EEE30B526FEDAED00696467 /* LocationError.swift in Sources */,
@@ -3095,6 +3130,7 @@
 				6EE66D7C29474DFF00E1F2F1 /* BookmarkListSection.swift in Sources */,
 				6E4FCD6C2939927A00B63C8B /* BaseCollectionReusableView.swift in Sources */,
 				6E3817B8293772B0008DA98A /* BookmarkService.swift in Sources */,
+				6E3BFD90298510F500563160 /* BookmarkViewerView.swift in Sources */,
 				6E826C4E2929CF0400B73B8F /* WebViewType.swift in Sources */,
 				6E7BF08125B7D5C000456D0B /* WriteDetailTypeStackView.swift in Sources */,
 				6E3493B2276481D10082B011 /* MedalCollectionCell.swift in Sources */,
@@ -3104,6 +3140,7 @@
 				6E61F48126F466410087C888 /* UIFontExtension.swift in Sources */,
 				6E82F8CB23D5D8A600AB3593 /* MyReviewViewModel.swift in Sources */,
 				6E41D97525CA5FE3009D7C3A /* PhotoListView.swift in Sources */,
+				6E3BFD8C29850BAB00563160 /* BookmarkViewerViewController.swift in Sources */,
 				6ED65D1E2944491A000E71B4 /* BookmarkListView.swift in Sources */,
 				6E66040927BBAA7B001EDF75 /* StreetFoodListEmptyCell.swift in Sources */,
 				6E72AE6523C9B7DE00D3B257 /* SignIn.swift in Sources */,
@@ -3304,6 +3341,7 @@
 				6E841F12294843D100956BBD /* BookmarkDeletePopupCoordinator.swift in Sources */,
 				6EE195922726DC6200FC4A0B /* StoreDetailCoordinator.swift in Sources */,
 				6E74879C2723DD7F0021DF93 /* StoreReviewTableView.swift in Sources */,
+				6E3BFD892985073400563160 /* DeeplinkType.swift in Sources */,
 				6E54BFE828963A1C00B7E608 /* BossStoreMenuCell.swift in Sources */,
 				6E4697C9273E182F005A5902 /* VisitType.swift in Sources */,
 				6E48B7A326C154C100E2F02B /* Pagination.swift in Sources */,
@@ -3431,6 +3469,7 @@
 				6E41F7EF23BB1F5600D0AC73 /* HomeStoreCell.swift in Sources */,
 				6E5CA5842768AEC4001EDE19 /* RegisteredStoreEmptyView.swift in Sources */,
 				6E57F29C273AA04D008C524A /* VisitCoordinator.swift in Sources */,
+				6E3BFD952985270900563160 /* BookmarkViewerStoreCollectionViewCell.swift in Sources */,
 				6E9D64D625BD6F160075DE36 /* DeleteMenuStackView.swift in Sources */,
 				6ED65D2629444D19000E71B4 /* BookmarkOverviewCollectionViewCell.swift in Sources */,
 				6ED6F1EE25B5561A00357B80 /* MenuHeaderView.swift in Sources */,
@@ -3444,6 +3483,7 @@
 				6E56BD7D23CDE216002D7092 /* StreetFoodStoreCategory.swift in Sources */,
 				6E8C190627A8239B00FF5B4C /* PopupPosition.swift in Sources */,
 				6E89DCE928AA787300327829 /* StreetFoodListHeaderView.swift in Sources */,
+				6E3BFD972985272D00563160 /* UICollectionViewExtension.swift in Sources */,
 				6E4813EF28A9C8020083B122 /* StreetFoodListMapCell.swift in Sources */,
 				6E01277529267095006B78DD /* SigninAnonymousCoordinator.swift in Sources */,
 				6E9D64E025BD751B0075DE36 /* DeleteReason.swift in Sources */,

--- a/3dollar-in-my-pocket.xcodeproj/project.pbxproj
+++ b/3dollar-in-my-pocket.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		6E3E994925E52B0E007BA379 /* StreetFoodListReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3E994825E52B0E007BA379 /* StreetFoodListReactor.swift */; };
 		6E3EDF3725694F7A0038E6A1 /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3EDF3625694F7A0038E6A1 /* SplashViewModel.swift */; };
 		6E3EDF3C25694F8C0038E6A1 /* BaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3EDF3B25694F8C0038E6A1 /* BaseViewModel.swift */; };
+		6E40195C29860E1D002DA1F6 /* UserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E40195B29860E1D002DA1F6 /* UserResponse.swift */; };
 		6E41661227464C8A0088E69C /* VisitOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E41661127464C8A0088E69C /* VisitOverview.swift */; };
 		6E41755226EE437500EA66B7 /* FAQCategoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E41755126EE437500EA66B7 /* FAQCategoryResponse.swift */; };
 		6E41755426EE458600EA66B7 /* FAQCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E41755326EE458600EA66B7 /* FAQCategory.swift */; };
@@ -698,6 +699,7 @@
 		6E3E994825E52B0E007BA379 /* StreetFoodListReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreetFoodListReactor.swift; sourceTree = "<group>"; };
 		6E3EDF3625694F7A0038E6A1 /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
 		6E3EDF3B25694F8C0038E6A1 /* BaseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewModel.swift; sourceTree = "<group>"; };
+		6E40195B29860E1D002DA1F6 /* UserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponse.swift; sourceTree = "<group>"; };
 		6E41661127464C8A0088E69C /* VisitOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitOverview.swift; sourceTree = "<group>"; };
 		6E41755126EE437500EA66B7 /* FAQCategoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FAQCategoryResponse.swift; sourceTree = "<group>"; };
 		6E41755326EE458600EA66B7 /* FAQCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FAQCategory.swift; sourceTree = "<group>"; };
@@ -2578,6 +2580,7 @@
 				6EDBBB7F2754C1EC00470F71 /* StoreWithVisitsResponse.swift */,
 				6E56FBC3289403EF00D8352C /* TimeIntervalResponse.swift */,
 				6E16EE2326BC1AC800F4DD03 /* UserInfoResponse.swift */,
+				6E40195B29860E1D002DA1F6 /* UserResponse.swift */,
 				6EDBBB7127546AF200470F71 /* UserWithActivityResponse.swift */,
 				6EDBBB7D2754BA1B00470F71 /* VisitHistoryCountsResponse.swift */,
 				6E4C1BE92753A932006C0F15 /* VisitHistoryWithStoreResponse.swift */,
@@ -3476,6 +3479,7 @@
 				6E451BDF26DD10D20056CDC4 /* UICollectionExtension.swift in Sources */,
 				6EF63FBD2761B2E90063A3B9 /* MyVisitHistoryViewController.swift in Sources */,
 				6E5F3F77289946950066E318 /* BossStoreFeedbackMeta.swift in Sources */,
+				6E40195C29860E1D002DA1F6 /* UserResponse.swift in Sources */,
 				6E0EA39923ABB230008F7CB2 /* SceneDelegate.swift in Sources */,
 				6EB6D0A525E728390017E09A /* StoreOrder.swift in Sources */,
 				6E07D44E23B5918B0055AEE7 /* WriteDetailVC.swift in Sources */,

--- a/3dollar-in-my-pocket.xcodeproj/project.pbxproj
+++ b/3dollar-in-my-pocket.xcodeproj/project.pbxproj
@@ -329,6 +329,8 @@
 		6E7E3E4E27642C6900A4C6E2 /* MyMedalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7E3E4D27642C6900A4C6E2 /* MyMedalViewController.swift */; };
 		6E7E3E5027642CBF00A4C6E2 /* MyMedalCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7E3E4F27642CBF00A4C6E2 /* MyMedalCoordinator.swift */; };
 		6E7E3E5427642F8B00A4C6E2 /* MyMedalCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7E3E5327642F8B00A4C6E2 /* MyMedalCollectionCell.swift */; };
+		6E7E5F5929814D24003747FC /* DeeplinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7E5F5829814D24003747FC /* DeeplinkManager.swift */; };
+		6E7E5F5C29815AE5003747FC /* Deeplink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7E5F5B29815AE5003747FC /* Deeplink.swift */; };
 		6E7EF40A25DE978C0014CD2B /* TabBarVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7EF40925DE978C0014CD2B /* TabBarVC.swift */; };
 		6E802088269A9608000A646E /* UserServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E802087269A9608000A646E /* UserServiceMock.swift */; };
 		6E810B0F259AEA3A0035315F /* AnalyticsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E810B0E259AEA3A0035315F /* AnalyticsScreen.swift */; };
@@ -886,6 +888,8 @@
 		6E7E3E4D27642C6900A4C6E2 /* MyMedalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyMedalViewController.swift; sourceTree = "<group>"; };
 		6E7E3E4F27642CBF00A4C6E2 /* MyMedalCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyMedalCoordinator.swift; sourceTree = "<group>"; };
 		6E7E3E5327642F8B00A4C6E2 /* MyMedalCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyMedalCollectionCell.swift; sourceTree = "<group>"; };
+		6E7E5F5829814D24003747FC /* DeeplinkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkManager.swift; sourceTree = "<group>"; };
+		6E7E5F5B29815AE5003747FC /* Deeplink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deeplink.swift; sourceTree = "<group>"; };
 		6E7EF40925DE978C0014CD2B /* TabBarVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarVC.swift; sourceTree = "<group>"; };
 		6E802087269A9608000A646E /* UserServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserServiceMock.swift; sourceTree = "<group>"; };
 		6E810B0E259AEA3A0035315F /* AnalyticsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsScreen.swift; sourceTree = "<group>"; };
@@ -2120,6 +2124,15 @@
 			path = cells;
 			sourceTree = "<group>";
 		};
+		6E7E5F5A29815AD6003747FC /* deeplink */ = {
+			isa = PBXGroup;
+			children = (
+				6E7E5F5829814D24003747FC /* DeeplinkManager.swift */,
+				6E7E5F5B29815AE5003747FC /* Deeplink.swift */,
+			);
+			path = deeplink;
+			sourceTree = "<group>";
+		};
 		6E810B10259AEA4A0035315F /* analytics */ = {
 			isa = PBXGroup;
 			children = (
@@ -2400,6 +2413,7 @@
 		6EB8FB9F25988D3300C17B74 /* manager */ = {
 			isa = PBXGroup;
 			children = (
+				6E7E5F5A29815AD6003747FC /* deeplink */,
 				6EB6F9EB289CE92A00D41AE3 /* toast */,
 				6EB46A5D2892BF630057B21A /* loading */,
 				6EEE30B326FEDAE600696467 /* location */,
@@ -3180,6 +3194,7 @@
 				6EC0D68026EB8891008AD34B /* FQAResponse.swift in Sources */,
 				6E1B64E02587A396003225F4 /* AFDataResponseExt.swift in Sources */,
 				6EA205F2288817C800BAB019 /* BossStoreMenuResponse.swift in Sources */,
+				6E7E5F5929814D24003747FC /* DeeplinkManager.swift in Sources */,
 				6ED65D2029444BB3000E71B4 /* BookmarkListViewController.swift in Sources */,
 				6E56BD7F23CDE291002D7092 /* Image.swift in Sources */,
 				6E25244625945BF0006EBDDB /* PopupViewModel.swift in Sources */,
@@ -3379,6 +3394,7 @@
 				6E5B359C28B3ACFE0056C223 /* FoodTruckListStoreCell.swift in Sources */,
 				6E54BFFB2896539100B7E608 /* BossStoreSectionModel.swift in Sources */,
 				6E9D64DB25BD73E10075DE36 /* DeleteModalReactor.swift in Sources */,
+				6E7E5F5C29815AE5003747FC /* Deeplink.swift in Sources */,
 				6E6835BE23C2CEFB00D23F54 /* RegisteredStoreCell.swift in Sources */,
 				6E3E0B8F23C7078100E835AE /* ReviewModalView.swift in Sources */,
 				6E3AA4D625AD6C3C00D8C58C /* Land.swift in Sources */,
@@ -3717,12 +3733,12 @@
 				API_URL = "https://dev.threedollars.co.kr";
 				APP_DISPLAY_NAME = "가슴속3천원-Dev";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				BOOKMARK_URL = "https://3dollarsdev.share.link/bookmark";
 				CODE_SIGN_ENTITLEMENTS = "3dollar-in-my-pocket/3dollar-in-my-pocket.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEEPLINK_HOST = "https://3dollars.share.link/";
 				DEVELOPMENT_TEAM = X975A2HM62;
 				DYNAMIC_LINK_URL = "https://3dollarsdev.page.link";
 				ENABLE_BITCODE = NO;
@@ -3766,11 +3782,11 @@
 				API_URL = "https://threedollars.co.kr";
 				APP_DISPLAY_NAME = "가슴속3천원";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				BOOKMARK_URL = "https://3dollars.share.link/bookmark";
 				CODE_SIGN_ENTITLEMENTS = "3dollar-in-my-pocket/3dollar-in-my-pocket.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEEPLINK_HOST = "https://3dollars.share.link/";
 				DEVELOPMENT_TEAM = X975A2HM62;
 				DYNAMIC_LINK_URL = "https://3dollars.page.link/bookmark";
 				ENABLE_BITCODE = NO;

--- a/3dollar-in-my-pocket/Info.plist
+++ b/3dollar-in-my-pocket/Info.plist
@@ -4,8 +4,8 @@
 <dict>
 	<key>DYNAMIC_LINK_URL</key>
 	<string>$(DYNAMIC_LINK_URL)</string>
-	<key>BOOKMARK_URL</key>
-	<string>$(BOOKMARK_URL)</string>
+	<key>DEEPLINK_HOST</key>
+	<string>$(DEEPLINK_HOST)</string>
 	<key>ADMOB_UNIT_ID</key>
 	<string>$(ADMOB_UNIT_ID)</string>
 	<key>API_URL</key>

--- a/3dollar-in-my-pocket/SceneDelegate.swift
+++ b/3dollar-in-my-pocket/SceneDelegate.swift
@@ -18,6 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.backgroundColor = UIColor.init(r: 28, g: 28, b: 28)
         window?.rootViewController = SplashVC.instance()
         window?.makeKeyAndVisible()
+        
         self.scene(scene, openURLContexts: connectionOptions.urlContexts)
     }
     
@@ -40,7 +41,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         guard let incomingURL = userActivity.webpageURL else { return }
         let linkHandled = DynamicLinks.dynamicLinks().handleUniversalLink(incomingURL) { dynamicLink, error in
-            Log.debug("url: \(dynamicLink?.url?.absoluteString ?? "")")
+            DeepLinkManager.shared.handleDeepLink(url: dynamicLink?.url)
         }
     }
     

--- a/3dollar-in-my-pocket/SceneDelegate.swift
+++ b/3dollar-in-my-pocket/SceneDelegate.swift
@@ -41,7 +41,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         guard let incomingURL = userActivity.webpageURL else { return }
         let linkHandled = DynamicLinks.dynamicLinks().handleUniversalLink(incomingURL) { dynamicLink, error in
-            DeepLinkManager.shared.handleDeepLink(url: dynamicLink?.url)
+            DeeplinkManager.shared.handleDeeplink(url: dynamicLink?.url)
         }
     }
     

--- a/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerView.swift
+++ b/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerView.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+final class BookmarkViewerView: BaseView {
+    let closeButton = UIButton().then {
+        $0.setImage(UIImage(named: "ic_close_white"), for: .normal)
+    }
+    
+    let collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewLayout()
+    ).then {
+        let layout = UICollectionViewCompositionalLayout { _, _ in
+            let item = NSCollectionLayoutItem(layoutSize: .init(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .absolute(BookmarkViewerStoreCollectionViewCell.height)
+            ))
+            let group = NSCollectionLayoutGroup.horizontal(layoutSize: .init(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .absolute(BookmarkViewerStoreCollectionViewCell.height)
+            ), subitems: [item])
+            let section = NSCollectionLayoutSection(group: group)
+            
+            section.boundarySupplementaryItems = [.init(
+                layoutSize: .init(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .estimated(400)
+                ),
+                elementKind: UICollectionView.elementKindSectionHeader,
+                alignment: .topLeading
+            )]
+            return section
+        }
+        
+        $0.collectionViewLayout = layout
+        $0.register([BookmarkViewerStoreCollectionViewCell.self])
+        $0.registerSectionHeader([BookmarkViewerHeaderView.self])
+        $0.backgroundColor = .clear
+    }
+    
+    override func setup() {
+        self.backgroundColor = Color.gray100
+        self.addSubViews([
+            self.closeButton,
+            self.collectionView
+        ])
+    }
+    
+    override func bindConstraints() {
+        self.closeButton.snp.makeConstraints { make in
+            make.right.equalToSuperview().offset(-25)
+            make.top.equalTo(self.safeAreaLayoutGuide).offset(10)
+            make.width.equalTo(25)
+            make.height.equalTo(25)
+        }
+        
+        self.collectionView.snp.makeConstraints { make in
+            make.left.equalToSuperview()
+            make.right.equalToSuperview()
+            make.bottom.equalToSuperview()
+            make.top.equalTo(self.closeButton.snp.bottom)
+        }
+    }
+}

--- a/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerViewController.swift
+++ b/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerViewController.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+final class BookmarkViewerViewController: BaseViewController {
+    private let bookmarkViewerView = BookmarkViewerView()
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+    
+    override func loadView() {
+        self.view = self.bookmarkViewerView
+    }
+    
+    static func instance(folderId: String) -> UINavigationController {
+        let viewController = BookmarkViewerViewController(nibName: nil, bundle: nil)
+        
+        return UINavigationController(rootViewController: viewController).then {
+            $0.modalPresentationStyle = .overCurrentContext
+            $0.isNavigationBarHidden = true
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.bookmarkViewerView.collectionView.dataSource = self
+        self.bookmarkViewerView.collectionView.delegate = self
+    }
+}
+
+// 뷰 테스트를 위해 임시로 작성한 코드입니다. 리액터 만들어지고 데이터 바인딩 되면 제거될 코드입니다.
+extension BookmarkViewerViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        return 1
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        let cell: BookmarkViewerStoreCollectionViewCell = collectionView.dequeueReuseableCell(
+            indexPath: indexPath
+        )
+        
+        return cell
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionReusableView {
+        let headerView: BookmarkViewerHeaderView = collectionView.dequeueReusableSupplementaryView(
+            ofkind: UICollectionView.elementKindSectionHeader,
+            indexPath: indexPath
+        )
+        
+        return headerView
+    }
+}

--- a/3dollar-in-my-pocket/domain/bookmark-viewer/cell/BookmarkViewerHeaderView.swift
+++ b/3dollar-in-my-pocket/domain/bookmark-viewer/cell/BookmarkViewerHeaderView.swift
@@ -1,0 +1,116 @@
+import UIKit
+
+final class BookmarkViewerHeaderView: BaseCollectionReusableView {
+    private let titleLabel = UILabel().then {
+        $0.text = "나만의 소중한\n음식플리ㅋㅎ"
+        $0.font = .bold(size: 30)
+        $0.numberOfLines = 0
+        $0.textColor = .white
+    }
+    
+    private let senderContainerView = UIView().then {
+        $0.backgroundColor = Color.gray90
+        $0.layer.cornerRadius = 16
+    }
+    
+    private let medalStackView = UIStackView().then {
+        $0.spacing = 5
+        $0.axis = .horizontal
+    }
+    
+    private let medalImageView = UIImageView().then {
+        $0.backgroundColor = .green
+    }
+    
+    private let medalLabel = UILabel().then {
+        $0.textColor = .white
+        $0.text = "따끈따끈한 뉴비"
+        $0.font = .regular(size: 12)
+    }
+    
+    private let bookmarkTitleLabel = UILabel().then {
+        $0.text = "마포구 몽키스패너님의 즐겨찾기"
+        $0.font = .regular(size: 16)
+        $0.textColor = .white
+    }
+    
+    private let bookmarkDescriptionLabel = UILabel().then {
+        $0.text = "제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 제가 엄선한 가게입니다 "
+        $0.textColor = Color.gray40
+        $0.numberOfLines = 0
+        $0.font = .regular(size: 12)
+    }
+    
+    private let backgroundContainerView = UIView().then {
+        $0.layer.cornerRadius = 20
+        $0.backgroundColor = Color.gray95
+    }
+    
+    private let countLabel = UILabel().then {
+        $0.text = "n개의 리스트"
+        $0.font = .bold(size: 12)
+        $0.textColor = Color.gray20
+    }
+    
+    override func setup() {
+        self.medalStackView.addArrangedSubview(self.medalImageView)
+        self.medalStackView.addArrangedSubview(self.medalLabel)
+        self.addSubViews([
+            self.backgroundContainerView,
+            self.titleLabel,
+            self.senderContainerView,
+            self.medalStackView,
+            self.bookmarkTitleLabel,
+            self.bookmarkDescriptionLabel,
+            self.countLabel
+        ])
+    }
+    
+    override func bindConstraints() {
+        self.backgroundContainerView.snp.makeConstraints { make in
+            make.left.equalToSuperview()
+            make.right.equalToSuperview()
+            make.top.equalToSuperview()
+            make.bottom.equalTo(self.bookmarkDescriptionLabel).offset(35)
+        }
+        
+        self.titleLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.backgroundContainerView).offset(19)
+        }
+        
+        self.senderContainerView.snp.makeConstraints { make in
+            make.left.equalToSuperview().offset(24)
+            make.right.equalToSuperview().offset(-24)
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(16)
+            make.bottom.equalTo(self.bookmarkTitleLabel).offset(11)
+        }
+        
+        self.medalImageView.snp.makeConstraints { make in
+            make.width.equalTo(16)
+            make.height.equalTo(16)
+        }
+        
+        self.medalStackView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.senderContainerView).offset(12)
+        }
+        
+        self.bookmarkTitleLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.medalStackView.snp.bottom).offset(6)
+        }
+        
+        self.bookmarkDescriptionLabel.snp.makeConstraints { make in
+            make.left.equalToSuperview().offset(24)
+            make.right.equalToSuperview().offset(-24)
+            make.top.equalTo(self.senderContainerView.snp.bottom).offset(18)
+        }
+        
+        self.countLabel.snp.makeConstraints { make in
+            make.left.equalToSuperview().offset(24)
+            make.top.equalTo(self.backgroundContainerView.snp.bottom).offset(28)
+            make.bottom.equalToSuperview().offset(-14)
+        }
+    }
+}

--- a/3dollar-in-my-pocket/domain/bookmark-viewer/cell/BookmarkViewerStoreCollectionViewCell.swift
+++ b/3dollar-in-my-pocket/domain/bookmark-viewer/cell/BookmarkViewerStoreCollectionViewCell.swift
@@ -1,0 +1,78 @@
+import UIKit
+
+final class BookmarkViewerStoreCollectionViewCell: BaseCollectionViewCell {
+    static let height: CGFloat = 92
+    
+    private let containerView = UIView().then {
+        $0.backgroundColor = Color.gray95
+        $0.layer.cornerRadius = 15
+    }
+    
+    private let categoryImageView = UIImageView().then {
+        $0.backgroundColor = .green
+    }
+    
+    private let storeTitleLabel = UILabel().then {
+        $0.font = .medium(size: 16)
+        $0.textColor = .white
+        $0.text = "강남역 0번 출구"
+        $0.textAlignment = .left
+    }
+    
+    private let categoryLabel = UILabel().then {
+        $0.font = .regular(size: 12)
+        $0.textColor = Color.gray30
+        $0.text = "#붕어빵 #땅콩과자 #호떡"
+        $0.textAlignment = .left
+    }
+    
+    private let rightArrowImageView = UIImageView().then {
+        $0.image = UIImage(named: "ic_right_arrow")
+    }
+    
+    override func setup() {
+        self.addSubViews([
+            self.containerView,
+            self.categoryImageView,
+            self.storeTitleLabel,
+            self.categoryLabel,
+            self.rightArrowImageView
+        ])
+    }
+    
+    override func bindConstraints() {
+        self.containerView.snp.makeConstraints { make in
+            make.left.equalToSuperview().offset(24)
+            make.right.equalToSuperview().offset(-24)
+            make.top.equalToSuperview().offset(6)
+            make.bottom.equalToSuperview().offset(-6)
+        }
+        
+        self.categoryImageView.snp.makeConstraints { make in
+            make.left.equalTo(self.containerView).offset(16)
+            make.top.equalTo(self.containerView).offset(16)
+            make.bottom.equalTo(self.containerView).offset(-16)
+            make.width.equalTo(48)
+            make.height.equalTo(48)
+        }
+        
+        self.storeTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.containerView).offset(20)
+            make.left.equalTo(self.categoryImageView.snp.right).offset(8)
+            make.right.equalTo(self.rightArrowImageView.snp.left).offset(-4)
+        }
+        
+        self.categoryLabel.snp.makeConstraints { make in
+            make.left.equalTo(self.storeTitleLabel)
+            make.right.equalTo(self.storeTitleLabel)
+            make.top.equalTo(self.storeTitleLabel.snp.bottom).offset(8)
+        }
+        
+        self.rightArrowImageView.snp.makeConstraints { make in
+            make.centerY.equalTo(self.containerView)
+            make.right.equalTo(self.containerView).offset(-16)
+            make.width.equalTo(14)
+            make.height.equalTo(14)
+        }
+    }
+}

--- a/3dollar-in-my-pocket/extension/BundleExtension.swift
+++ b/3dollar-in-my-pocket/extension/BundleExtension.swift
@@ -21,8 +21,8 @@ extension Bundle {
         return Bundle.main.infoDictionary?["DYNAMIC_LINK_URL"] as? String ?? ""
     }
     
-    static var bookmarkURL: String {
-        return Bundle.main.infoDictionary?["BOOKMARK_URL"] as? String ?? ""
+    static var deeplinkHost: String {
+        return Bundle.main.infoDictionary?["DEEPLINK_HOST"] as? String ?? ""
     }
     
     static var bundleId: String {

--- a/3dollar-in-my-pocket/extension/UICollectionViewExtension.swift
+++ b/3dollar-in-my-pocket/extension/UICollectionViewExtension.swift
@@ -1,0 +1,51 @@
+import UIKit
+
+extension UICollectionView {
+    func register(_ cellTypes: [UICollectionViewCell.Type]) {
+        for cellType in cellTypes {
+            self.register(cellType, forCellWithReuseIdentifier: "\(cellType.self)")
+        }
+    }
+    
+    func registerSectionHeader(_ viewTypes: [UICollectionReusableView.Type]) {
+        for viewType in viewTypes {
+            self.register(
+                viewType,
+                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+                withReuseIdentifier: "\(viewType.self)"
+            )
+        }
+    }
+    
+    func registerSectionFooter(_ viewTypes: [UICollectionReusableView.Type]) {
+        for viewType in viewTypes {
+            self.register(
+                viewType,
+                forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter,
+                withReuseIdentifier: "\(viewType.self)"
+            )
+        }
+    }
+    
+    func dequeueReuseableCell<T: UICollectionViewCell>(indexPath: IndexPath) -> T {
+        guard let cell = self.dequeueReusableCell(
+            withReuseIdentifier: "\(T.self)",
+            for: indexPath
+        ) as? T else { fatalError("정의되지 않은 UICollectionViewCell 입니다.") }
+        
+        return cell
+    }
+    
+    func dequeueReusableSupplementaryView<T: UICollectionReusableView>(
+        ofkind: String,
+        indexPath: IndexPath
+    ) -> T {
+        guard let view = self.dequeueReusableSupplementaryView(
+            ofKind: ofkind,
+            withReuseIdentifier: "\(T.self)",
+            for: indexPath
+        ) as? T else { fatalError("정의되지 않은 UICollectionReusableView 입니다.") }
+        
+        return view
+    }
+}

--- a/3dollar-in-my-pocket/manager/deeplink/Deeplink.swift
+++ b/3dollar-in-my-pocket/manager/deeplink/Deeplink.swift
@@ -3,10 +3,10 @@ import Foundation
 enum Deeplink {
     case bookmark(folderId: String)
     
-    var path: String {
+    var type: DeeplinkType {
         switch self {
         case .bookmark:
-            return "bookmark"
+            return .bookmark
         }
     }
     
@@ -18,7 +18,7 @@ enum Deeplink {
     }
     
     var url: URL? {
-        var component = URLComponents(string: Bundle.deeplinkHost + path + "?")
+        var component = URLComponents(string: Bundle.deeplinkHost + type.path + "?")
         
         if let parameters = parameters {
             for parameter in parameters {

--- a/3dollar-in-my-pocket/manager/deeplink/Deeplink.swift
+++ b/3dollar-in-my-pocket/manager/deeplink/Deeplink.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 enum Deeplink {
     case bookmark(folderId: String)
     
@@ -9,6 +11,26 @@ enum Deeplink {
     }
     
     var parameters: [String: String]? {
+        switch self {
+        case .bookmark(let folderId):
+            return ["folderId": folderId]
+        }
+    }
+    
+    var url: URL? {
+        var component = URLComponents(string: Bundle.deeplinkHost + path + "?")
         
+        if let parameters = parameters {
+            for parameter in parameters {
+                let queryItem = URLQueryItem(
+                    name: parameter.key,
+                    value: parameter.value
+                )
+                
+                component?.queryItems?.append(queryItem)
+            }
+        }
+        
+        return component?.url
     }
 }

--- a/3dollar-in-my-pocket/manager/deeplink/Deeplink.swift
+++ b/3dollar-in-my-pocket/manager/deeplink/Deeplink.swift
@@ -1,0 +1,14 @@
+enum Deeplink {
+    case bookmark(folderId: String)
+    
+    var path: String {
+        switch self {
+        case .bookmark:
+            return "bookmark"
+        }
+    }
+    
+    var parameters: [String: String]? {
+        
+    }
+}

--- a/3dollar-in-my-pocket/manager/deeplink/DeeplinkManager.swift
+++ b/3dollar-in-my-pocket/manager/deeplink/DeeplinkManager.swift
@@ -9,21 +9,34 @@ final class DeeplinkManager: DeeplinkManagerProtocol {
     
     func handleDeeplink(url: URL?) {
         guard let url = url,
-        let host = url.host else {
+        self.validateHost(host: url.host) else {
             Log.debug("URL 형식이 아닙니다.")
             return
         }
-        Log.debug(
-                """
-                \nurl: \(url.absoluteString)
-                host: \(url.host)
-                path: \(url.pathComponents)
-                params: \(url.params())
-                """
-        )
+        
+        switch DeeplinkType(rawValue: url.relativePath) {
+        case .bookmark:
+            guard let params = url.params(),
+                  let param = params.first,
+                  param.key == "folderId",
+                  let folderId = param.value as? String else { return }
+            let viewController = BookmarkViewerViewController.instance(folderId: folderId)
+            
+            
+            if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+                sceneDelegate.window?.rootViewController?.present(viewController, animated: true)
+            }
+            
+            
+            Log.debug("params: \(url.params())")
+            
+        default:
+            Log.debug("지원하는 Deeplink가 아닙니다.")
+            break
+        }
     }
     
-    private func validateHost(host: String) -> Bool {
-        return false
+    private func validateHost(host: String?) -> Bool {
+        return host == URL(string: Bundle.deeplinkHost)?.host
     }
 }

--- a/3dollar-in-my-pocket/manager/deeplink/DeeplinkManager.swift
+++ b/3dollar-in-my-pocket/manager/deeplink/DeeplinkManager.swift
@@ -24,6 +24,6 @@ final class DeeplinkManager: DeeplinkManagerProtocol {
     }
     
     private func validateHost(host: String) -> Bool {
-        
+        return false
     }
 }

--- a/3dollar-in-my-pocket/manager/deeplink/DeeplinkManager.swift
+++ b/3dollar-in-my-pocket/manager/deeplink/DeeplinkManager.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+protocol DeeplinkManagerProtocol: AnyObject {
+    func handleDeeplink(url: URL?)
+}
+
+final class DeeplinkManager: DeeplinkManagerProtocol {
+    static let shared = DeeplinkManager()
+    
+    func handleDeeplink(url: URL?) {
+        guard let url = url,
+        let host = url.host else {
+            Log.debug("URL 형식이 아닙니다.")
+            return
+        }
+        Log.debug(
+                """
+                \nurl: \(url.absoluteString)
+                host: \(url.host)
+                path: \(url.pathComponents)
+                params: \(url.params())
+                """
+        )
+    }
+    
+    private func validateHost(host: String) -> Bool {
+        
+    }
+}

--- a/3dollar-in-my-pocket/manager/deeplink/DeeplinkType.swift
+++ b/3dollar-in-my-pocket/manager/deeplink/DeeplinkType.swift
@@ -1,0 +1,7 @@
+enum DeeplinkType: String {
+    case bookmark = "/bookmark"
+    
+    var path: String {
+        self.rawValue
+    }
+}

--- a/3dollar-in-my-pocket/model/dto/response/UserFavoriteStoreFolderResponse.swift
+++ b/3dollar-in-my-pocket/model/dto/response/UserFavoriteStoreFolderResponse.swift
@@ -4,5 +4,5 @@ struct UserFavoriteStoreFolderResponse: Decodable {
     let folderId: String?
     let introduction: String
     let name: String
-    let user: UserPublicInfoResponse
+    let user: UserResponse
 }

--- a/3dollar-in-my-pocket/model/dto/response/UserResponse.swift
+++ b/3dollar-in-my-pocket/model/dto/response/UserResponse.swift
@@ -1,0 +1,6 @@
+struct UserResponse: Decodable {
+    let medal: MedalResponse
+    let name: String
+    let socialType: String
+    let userId: Int
+}

--- a/3dollar-in-my-pocket/model/presentation/User.swift
+++ b/3dollar-in-my-pocket/model/presentation/User.swift
@@ -37,10 +37,10 @@ struct User: Equatable {
         self.marketingConsent = .unknown
     }
     
-    init(response: UserPublicInfoResponse) {
+    init(response: UserResponse) {
         self.name = response.name
-        self.userId = -1
-        self.socialType = .unknown
+        self.userId = response.userId
+        self.socialType = SocialType(value: response.socialType)
         self.activity = UserActivity()
         self.medal = Medal(response: response.medal)
         self.pushInfo = PushInfo()

--- a/3dollar-in-my-pocket/services/BookmarkService.swift
+++ b/3dollar-in-my-pocket/services/BookmarkService.swift
@@ -91,7 +91,7 @@ struct BookmarkService: BookmarkServiceProtocol {
     
     func createBookmarkURL(folderId: String) -> Observable<String> {
         return .create { observer in
-            guard let link = URL(string: Bundle.bookmarkURL + "?folderId=\(folderId)") else {
+            guard let link = Deeplink.bookmark(folderId: folderId).url else {
                 observer.onError(BaseError.custom("URL 형식이 잘못되었습니다."))
                 return Disposables.create()
             }

--- a/3dollar-in-my-pocket/services/BookmarkService.swift
+++ b/3dollar-in-my-pocket/services/BookmarkService.swift
@@ -15,6 +15,9 @@ protocol BookmarkServiceProtocol {
     func editBookmarkFolder(introduction: String, name: String) -> Observable<String>
     
     func createBookmarkURL(folderId: String) -> Observable<String>
+    
+    func fetchBookmarkFolder(folderId: String, cursor: String?)
+    -> Observable<(cursor: Cursor, BookmarkFolder: BookmarkFolder)>
 }
 
 struct BookmarkService: BookmarkServiceProtocol {
@@ -121,5 +124,23 @@ struct BookmarkService: BookmarkServiceProtocol {
             
             return Disposables.create()
         }
+    }
+    
+    func fetchBookmarkFolder(folderId: String, cursor: String? = nil)
+    -> Observable<(cursor: Cursor, BookmarkFolder: BookmarkFolder)> {
+        let urlString = HTTPUtils.url + "/api/v1/favorite/store/folder/target/\(folderId)"
+        let headers = HTTPUtils.defaultHeader()
+        let parameters: [String: Any] = [
+            "cursor": cursor as Any,
+            "size": 20
+        ]
+        
+        return self.networkManager.createGetObservable(
+            class: UserFavoriteStoreFolderResponse.self,
+            urlString: urlString,
+            headers: headers,
+            parameters: parameters
+        )
+        .map { (Cursor(response: $0.cursor), BookmarkFolder(response: $0)) }
     }
 }


### PR DESCRIPTION
## Overview 👩🏻‍💻
Linked Issue: #67
Linked Figma: 피그마와 무관합니다.

## 변경 내용 ⚒️
- #77 PR이 선행되어야 합니다.
- 즐겨찾기 뷰어 화면에서 사용하는 API service 함수를 정의했습니다.
  - [[GET] /api/v1/favorite/store/folder/target/{favoriteFolderId}](https://dev.threedollars.co.kr/api/swagger-ui/index.html#/favorite-store-folder-retrieve-controller/retrieveTargetFavoriteStoreFolderUsingGET)
- API에서 사용하는 도메인 모델도 같이 정의했습니다.

## 스크린샷 📷
- 스크린샷과 무관합니다.

## 테스트 방법
- 서비스 구현이므로 테스트 과정이 없습니다.