### PR TITLE
[닉네임 화면] 닉네임 화면 생성자에 딥링크 같이 인자로 받도록 수정 #82 

### DIFF
--- a/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerCoordinator.swift
+++ b/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerCoordinator.swift
@@ -7,7 +7,7 @@ protocol BookmarkViewerCoordinator: BaseCoordinator, AnyObject {
     
     func goToMain(with folderId: String)
     
-    func pushNickname(signinRequest: SigninRequest)
+    func pushNickname(signinRequest: SigninRequest, bookmarkFolderId: String?)
 }
 
 extension BookmarkViewerCoordinator {
@@ -44,8 +44,11 @@ extension BookmarkViewerCoordinator {
         }
     }
     
-    func pushNickname(signinRequest: SigninRequest) {
-        let viewController = NicknameViewController.instance(signinRequest: signinRequest)
+    func pushNickname(signinRequest: SigninRequest, bookmarkFolderId: String?) {
+        let viewController = NicknameViewController.instance(
+            signinRequest: signinRequest,
+            bookmarkFolderId: bookmarkFolderId
+        )
         
         self.presenter.navigationController?.pushViewController(
             viewController,

--- a/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerReactor.swift
+++ b/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerReactor.swift
@@ -7,6 +7,7 @@ final class BookmarkViewerReactor: BaseReactor, Reactor {
         case willDisplay(row: Int)
         case tapStore(row: Int)
         case onSuccessSignin
+        case onFailSignin(SigninRequest)
     }
     
     enum Mutation {
@@ -19,6 +20,10 @@ final class BookmarkViewerReactor: BaseReactor, Reactor {
         case pushFoodTruckDetail(String)
         case presentSigninDialog
         case goToMainWithFolderId(String)
+        case pushNicknameWithFolderId(
+            signinRequest: SigninRequest,
+            folderId: String
+        )
         case showErrorAlert(Error)
     }
     
@@ -32,6 +37,7 @@ final class BookmarkViewerReactor: BaseReactor, Reactor {
         @Pulse var pushFoodTruckDetail: String?
         @Pulse var presentSigninDialog: Void?
         @Pulse var goToMainWithFolderId: String?
+        @Pulse var pushNicknameWithFolderId: (SigninRequest, String)?
     }
     
     let initialState: State
@@ -89,6 +95,12 @@ final class BookmarkViewerReactor: BaseReactor, Reactor {
             
         case .onSuccessSignin:
             return .just(.goToMainWithFolderId(self.folderId))
+            
+        case .onFailSignin(let signinRequest):
+            return .just(.pushNicknameWithFolderId(
+                signinRequest: signinRequest,
+                folderId: self.folderId
+            ))
         }
     }
     
@@ -122,6 +134,9 @@ final class BookmarkViewerReactor: BaseReactor, Reactor {
             
         case .goToMainWithFolderId(let folderId):
             newState.goToMainWithFolderId = folderId
+            
+        case .pushNicknameWithFolderId(let signinRequest, let folderId):
+            newState.pushNicknameWithFolderId = (signinRequest, folderId)
             
         case .showErrorAlert(let error):
             self.showErrorAlertPublisher.accept(error)

--- a/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerViewController.swift
+++ b/3dollar-in-my-pocket/domain/bookmark-viewer/BookmarkViewerViewController.swift
@@ -112,6 +112,14 @@ final class BookmarkViewerViewController: BaseViewController, View, BookmarkView
                 self?.coodinator?.goToMain(with: folderId)
             })
             .disposed(by: self.disposeBag)
+        
+        reactor.pulse(\.$pushNicknameWithFolderId)
+            .compactMap { $0 }
+            .asDriver(onErrorJustReturn: (SigninRequest(socialType: .unknown, token: ""), ""))
+            .drive(onNext: { [weak self] parameters in
+                self?.coodinator?.pushNickname(signinRequest: parameters.0, bookmarkFolderId: parameters.1)
+            })
+            .disposed(by: self.disposeBag)
     }
     
     private func setupDataSource() {
@@ -178,6 +186,6 @@ extension BookmarkViewerViewController: BookmarkSigninDialogViewControllerDelega
     }
     
     func whenAccountNotExisted(signinRequest: SigninRequest) {
-        self.coodinator?.pushNickname(signinRequest: signinRequest)
+        self.bookmarkViewerReactor.action.onNext(.onFailSignin(signinRequest))
     }
 }

--- a/3dollar-in-my-pocket/domain/membership/nickname/NicknameCooridnator.swift
+++ b/3dollar-in-my-pocket/domain/membership/nickname/NicknameCooridnator.swift
@@ -1,7 +1,7 @@
 protocol NicknameCoordinator: BaseCoordinator, AnyObject {
     func presentPolicy()
     
-    func goToMain()
+    func goToMain(with bookmarkFolderId: String?)
 }
 
 extension NicknameCoordinator where Self: NicknameViewController {
@@ -11,7 +11,18 @@ extension NicknameCoordinator where Self: NicknameViewController {
         self.present(viewController, animated: true)
     }
     
-    func goToMain() {
+    func goToMain(with bookmarkFolderId: String?) {
         SceneDelegate.shared?.goToMain()
+        
+        if let bookmarkFolderId {
+            let targetViewController = BookmarkViewerViewController.instance(
+                folderId: bookmarkFolderId
+            )
+            let deepLinkContents = DeepLinkContents(
+                targetViewController: targetViewController,
+                transitionType: .present
+            )
+            DeeplinkManager.shared.deeplinkPublisher.accept(deepLinkContents)
+        }
     }
 }

--- a/3dollar-in-my-pocket/domain/membership/nickname/NicknameReactor.swift
+++ b/3dollar-in-my-pocket/domain/membership/nickname/NicknameReactor.swift
@@ -6,6 +6,7 @@ final class NicknameReactor: BaseReactor, Reactor {
     enum Action {
         case inputNickname(String)
         case tapStartButton
+        case onSignupSuccess
     }
     
     enum Mutation {
@@ -13,6 +14,7 @@ final class NicknameReactor: BaseReactor, Reactor {
         case setStartButtonEnable(Bool)
         case setErrorLabelHidden(Bool)
         case presentPolicy
+        case goToMain(bookmarkFolderId: String?)
         case showLoading(isShow: Bool)
         case showErrorAlert(error: Error)
     }
@@ -25,13 +27,16 @@ final class NicknameReactor: BaseReactor, Reactor {
     }
     
     let initialState: State
+    let goToMainPublisher = PublishRelay<String?>()
     private let signinRequest: SigninRequest
+    private let bookmarkFolderId: String?
     private var userDefaults: UserDefaultsUtil
     private let userService: UserServiceProtocol
     var isSignupSuccess = false
     
     init(
         signinRequest: SigninRequest,
+        bookmarkFolderId: String? = nil,
         userDefaults: UserDefaultsUtil,
         userService: UserServiceProtocol,
         state: State = State(
@@ -41,6 +46,7 @@ final class NicknameReactor: BaseReactor, Reactor {
         )
     ) {
         self.signinRequest = signinRequest
+        self.bookmarkFolderId = bookmarkFolderId
         self.userDefaults = userDefaults
         self.userService = userService
         self.initialState = state
@@ -64,6 +70,9 @@ final class NicknameReactor: BaseReactor, Reactor {
                 self.setNickname(nickname: nickname),
                 .just(.showLoading(isShow: false))
             ])
+            
+        case .onSignupSuccess:
+            return .just(.goToMain(bookmarkFolderId: self.bookmarkFolderId))
         }
     }
     
@@ -82,6 +91,9 @@ final class NicknameReactor: BaseReactor, Reactor {
             
         case .presentPolicy:
             newState.presentPolicy = ()
+            
+        case .goToMain(let bookmarkFolderId):
+            self.goToMainPublisher.accept(bookmarkFolderId)
             
         case .showLoading(let isShow):
             self.showLoadingPublisher.accept(isShow)

--- a/3dollar-in-my-pocket/domain/membership/nickname/NicknameViewController.swift
+++ b/3dollar-in-my-pocket/domain/membership/nickname/NicknameViewController.swift
@@ -12,13 +12,20 @@ final class NicknameViewController: BaseViewController, View, NicknameCoordinato
         return .lightContent
     }
     
-    static func instance(signinRequest: SigninRequest) -> NicknameViewController {
-        return NicknameViewController(signinRequest: signinRequest)
+    static func instance(
+        signinRequest: SigninRequest,
+        bookmarkFolderId: String? = nil
+    ) -> NicknameViewController {
+        return NicknameViewController(
+            signinRequest: signinRequest,
+            bookmarkFolderId: bookmarkFolderId
+        )
     }
   
-    init(signinRequest: SigninRequest) {
+    init(signinRequest: SigninRequest, bookmarkFolderId: String?) {
         self.nicknameReactor = NicknameReactor(
             signinRequest: signinRequest,
+            bookmarkFolderId: bookmarkFolderId,
             userDefaults: UserDefaultsUtil(),
             userService: UserService()
         )
@@ -57,6 +64,13 @@ final class NicknameViewController: BaseViewController, View, NicknameCoordinato
             .asDriver(onErrorJustReturn: ())
             .drive(onNext: { [weak self] _ in
                 self?.nicknameView.hideKeyboard()
+            })
+            .disposed(by: self.eventDisposeBag)
+        
+        self.nicknameReactor.goToMainPublisher
+            .asDriver(onErrorJustReturn: nil)
+            .drive(onNext: { [weak self] bookmarkFolderId in
+                self?.coordinator?.goToMain(with: bookmarkFolderId)
             })
             .disposed(by: self.eventDisposeBag)
         
@@ -122,6 +136,6 @@ final class NicknameViewController: BaseViewController, View, NicknameCoordinato
 
 extension NicknameViewController: PolicyViewControllerDelegate {
     func onDismiss() {
-        self.coordinator?.goToMain()
+        self.nicknameReactor.action.onNext(.onSignupSuccess)
     }
 }


### PR DESCRIPTION
## Overview 👩🏻‍💻
Linked Issue: #82

## 변경 내용 ⚒️
- 닉네임 화면 생성자로 즐겨찾기의 folderId를 같이 받을 수 있도록 수정했습니다.
- 즐겨찾기 공유하기 화면에서도 회원가입을 진행할 수 있는 케이스가 생겨나서 대응을 위해 적용했습니다.
- 즐겨찾기 folderId와 함께 회원가입이 진행되면 회원가입 진행 완료 후, 홈 화면에서 즐겨찾기 공유화면을 다시 띄워줍니다.

## 스크린샷 📷


https://user-images.githubusercontent.com/7058293/216804523-fcdf7544-8671-485d-81ed-c34844f79ff5.mov


## 테스트 방법
1. 비로그인 상태로 즐겨찾기 뷰어링크 눌러 뷰어 화면 진입
2. 회원가입 진행
3. 회원가입 완료 후, 홈 화면으로 넘어가면서 즐겨찾기 뷰어가 다시 나오는지 확인