### PR TITLE
fix: 카카오톡 로그인 취소 시, 로딩화면 꺼지지 않는 오류 수정 #81

### DIFF
--- a/3dollar-in-my-pocket/manager/signin/KakaoSigninManager.swift
+++ b/3dollar-in-my-pocket/manager/signin/KakaoSigninManager.swift
@@ -105,7 +105,9 @@ final class KakaoSigninManager: SigninManagerProtocol {
                     if sdkError.isClientFailed {
                         switch sdkError.getClientError().reason {
                         case .Cancelled:
-                            break
+                            let error = BaseError.custom("cancel")
+                            
+                            self.publisher.onError(error)
                         default:
                             let errorMessage = sdkError.getApiError().info?.msg ?? ""
                             let error = BaseError.custom(errorMessage)


### PR DESCRIPTION
## Overview
Linked Issue: #81 

## 현상
- 카카오톡 로그인 중, 취소 버튼을 누르거나 바텀시트 내리기를 통해 취소하는 경우, 로딩 로띠가 꺼지지 않습니다.
- 스크린샷은 #81 에 첨부되어있습니다.

## 원인
- 카카오톡 로그인 취소 시, KakaoSigninManager에서 아무런 액션을 하지 않고 break됩니다.
- 로딩 화면을 끄기 위해서는 SigninReactor에서 취소했는지 여부를 받아 로딩 화면을 꺼야하는데, 끄지 않고 있습니다.

## 해결 방법
- KakaoSigninManager에서 취소 시, cancel Error를 발생시켜 SigninReactor에서 취소 여부를 파악할 수 있도록 수정했습니다.

## 테스트 케이스
- 로그인 화면 > 카카오로 로그인 > 로그인 중 취소버튼을 눌러 로그인 화면으로 복귀
    - 로딩 화면이 사라지는가?

