### PR TITLE
fix: 푸드트럭 상세화면 메뉴 더보기 뷰에 localization 깨지는 오류 수정

### DIFF
--- a/3dollar-in-my-pocket/domain/boss-store-detail/subviews/cells/BossStoreMoreMenuCell.swift
+++ b/3dollar-in-my-pocket/domain/boss-store-detail/subviews/cells/BossStoreMoreMenuCell.swift
@@ -74,7 +74,7 @@ final class BossStoreMoreMenuCell: BaseCollectionViewCell {
     
     func bind(menus: [BossStoreMenu]) {
         self.titleLabel.text = String.init(
-            format: String(format: "localization.boss_store_more_menu".localized, menus.count)
+            format: String(format: "boss_store_more_menu".localized, menus.count)
         )
         
         for menu in menus {


### PR DESCRIPTION
## Overview
Linked Issue: 이슈 없이 슬랙에서 언급된 버그입니다.

## 현상
- 홈 > 푸드트럭 상세화면 진입 시, 푸드트럭 메뉴가 6개 이상일 떄, 하단에 n개의 메뉴가 더 있습니다 뷰의 텍스트가 깨져서 보여집니다.

## 원인
- Localization id가 이상하게 들어가 있었습니다.. 🤔

## 해결 방법
- 올바른 Localization id로 변경했습니다.

## 테스트 케이스
|Before|After|
|------|-----|
|<image src="https://user-images.githubusercontent.com/7058293/231677043-9e6f87b7-dde3-44a0-8377-c69db75f96ee.jpeg" width=360>|<image src="https://user-images.githubusercontent.com/7058293/231677080-c3e0c2b1-6e5f-4c56-a83e-ada363f468b5.jpeg" width=360>|
