### PR TITLE
제보 화면 주소 설정 중복 팝업 구현

### DIFF
--- a/App/Derived/Sources/TuistStrings+ThreeDollarInMyPocket.swift
+++ b/App/Derived/Sources/TuistStrings+ThreeDollarInMyPocket.swift
@@ -594,7 +594,7 @@ public enum ThreeDollarInMyPocketStrings {
   public static let writeAddressButton = ThreeDollarInMyPocketStrings.tr("Localization", "write_address_button")
   /// 중복된 가게 제보인지 확인해 주세요.
   public static let writeAddressConfirmPopupDescription = ThreeDollarInMyPocketStrings.tr("Localization", "write_address_confirm_popup_description")
-  /// 이 위치가 맞아요!
+  /// 여기가 확실해요
   public static let writeAddressConfirmPopupOk = ThreeDollarInMyPocketStrings.tr("Localization", "write_address_confirm_popup_ok")
   /// 10m이내에 이미 제보된\n가게가 있어요! 
   public static let writeAddressConfirmPopupTitle = ThreeDollarInMyPocketStrings.tr("Localization", "write_address_confirm_popup_title")

--- a/App/Targets/three-dollar-in-my-pocket/Resources/en.lproj/Localization.strings
+++ b/App/Targets/three-dollar-in-my-pocket/Resources/en.lproj/Localization.strings
@@ -110,7 +110,7 @@
 "write_address_unknown" = "주소를 알 수 없는 위치입니다.";
 "write_address_confirm_popup_title" = "10m이내에 이미 제보된\n가게가 있어요! ";
 "write_address_confirm_popup_description" = "중복된 가게 제보인지 확인해 주세요.";
-"write_address_confirm_popup_ok" = "이 위치가 맞아요!";
+"write_address_confirm_popup_ok" = "여기가 확실해요";
 "write_location" = "가게 위치";
 "write_modify_location" = "수정하기";
 "write_store_info" = "가게 정보";

--- a/App/Targets/three-dollar-in-my-pocket/Resources/ko.lproj/Localization.strings
+++ b/App/Targets/three-dollar-in-my-pocket/Resources/ko.lproj/Localization.strings
@@ -110,7 +110,7 @@
 "write_address_unknown" = "주소를 알 수 없는 위치입니다.";
 "write_address_confirm_popup_title" = "10m이내에 이미 제보된\n가게가 있어요! ";
 "write_address_confirm_popup_description" = "중복된 가게 제보인지 확인해 주세요.";
-"write_address_confirm_popup_ok" = "이 위치가 맞아요!";
+"write_address_confirm_popup_ok" = "여기가 확실해요";
 "write_location" = "가게 위치";
 "write_modify_location" = "수정하기";
 "write_store_info" = "가게 정보";

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseBottomSheetViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseBottomSheetViewController.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+class BaseBottomSheetViewController: BaseViewController {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        
+        modalPresentationStyle = .overCurrentContext
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        if let parentView = presentingViewController?.view {
+            DimManager.shared.showDim(targetView: parentView)
+        }
+    }
+    
+    func dismiss(completion: (() -> Void)? = nil) {
+        DimManager.shared.hideDim()
+        dismiss(animated: true, completion: completion)
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseCoordinator.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseCoordinator.swift
@@ -8,6 +8,8 @@ protocol BaseCoordinator {
     func showLoading(isShow: Bool)
     func showToast(message: String)
     func showToast(message: String, baseView: UIView)
+    func dismiss(completion: (() -> Void)?)
+    func dismiss()
 }
 
 extension BaseCoordinator where Self: BaseViewController {
@@ -67,6 +69,16 @@ extension BaseCoordinator where Self: BaseViewController {
         ToastManager.shared.show(message: message)
     }
     
+    func dismiss(completion: (() -> Void)? = nil) {
+        if presenter is BaseBottomSheetViewController {
+            DimManager.shared.hideDim()
+        }
+        presenter.dismiss(animated: true, completion: completion)
+    }
+    
+    func dismiss() {
+        dismiss(completion: nil)
+    }
     
     private func goToSignin() {
         if let sceneDelegate

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseViewController.swift
@@ -1,17 +1,34 @@
 import UIKit
+import Combine
 
 import RxSwift
 
 class BaseViewController: UIViewController {
     var disposeBag = DisposeBag()
     var eventDisposeBag = DisposeBag()
+    var cancellables = Set<AnyCancellable>()
+    
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        
+        bindViewModelInput()
+        bindViewModelOutput()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.bindEvent()
+        bindEvent()
     }
     
     /// Reactor를 거치지 않고 바로 바인딩 되는 단순 이벤트를 정의합니다.
     func bindEvent() { }
+    
+    func bindViewModelInput() { }
+    
+    func bindViewModelOutput() { }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressCoordinator.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressCoordinator.swift
@@ -17,7 +17,6 @@ extension WriteAddressCoordinator where Self: BaseVC {
         let viewController = AddressConfirmPopupViewController.instacne(address: address)
         
         viewController.delegate = self as? AddressConfirmPopupViewControllerDelegate
-        showRootDim(isShow: true)
         presenter.present(viewController, animated: true, completion: nil)
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressCoordinator.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressCoordinator.swift
@@ -1,10 +1,10 @@
-protocol WriteAddressCoordinator: AnyObject, Coordinator {
+protocol WriteAddressCoordinator: AnyObject, BaseCoordinator {
     func goToWriteDetail(address: String, location: (Double, Double))
     
     func presentConfirmPopup(address: String)
 }
 
-extension WriteAddressCoordinator where Self: BaseVC {
+extension WriteAddressCoordinator where Self: BaseViewController {
     func goToWriteDetail(address: String, location: (Double, Double)) {
         let viewController = WriteDetailVC.instance(address: address, location: location)
         

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressViewController.swift
@@ -10,7 +10,7 @@ protocol WriteAddressDelegate: AnyObject {
     func onWriteSuccess(storeId: Int)
 }
 
-final class WriteAddressViewController: BaseVC, WriteAddressCoordinator {
+final class WriteAddressViewController: BaseViewController, WriteAddressCoordinator {
     weak var delegate: WriteAddressDelegate?
     private let writeAddressView = WriteAddressView()
     private let viewModel = WriteAddressViewModel(
@@ -20,8 +20,6 @@ final class WriteAddressViewController: BaseVC, WriteAddressCoordinator {
         analyticsManager: AnalyticsManager.shared
     )
     private weak var coordinator: WriteAddressCoordinator?
-    private var cancellables = Set<AnyCancellable>()
-    
     
     static func instance(delegate: WriteAddressDelegate) -> UINavigationController {
         let writeAddressVC = WriteAddressViewController(nibName: nil, bundle: nil).then {
@@ -164,12 +162,7 @@ extension WriteAddressViewController: WriteDetailDelegate {
 }
 
 extension WriteAddressViewController: AddressConfirmPopupViewControllerDelegate {
-    func onDismiss() {
-        showRootDim(isShow: false)
-    }
-    
     func onClickOk() {
-        showRootDim(isShow: false)
         viewModel.input.tapConfirmAddress.send(())
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupCoordinator.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupCoordinator.swift
@@ -1,3 +1,3 @@
-protocol AddressConfirmPopupCoordinator: AnyObject, Coordinator {
+protocol AddressConfirmPopupCoordinator: AnyObject, BaseCoordinator {
     
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupView.swift
@@ -1,23 +1,25 @@
 import UIKit
 
+import DesignSystem
+
 final class AddressConfirmPopupView: BaseView {
     let tapBackground = UITapGestureRecognizer()
     
     private let backgroundView = UIView()
     
     private let containerView = UIView().then {
-        $0.backgroundColor = .white
+        $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         $0.layer.cornerRadius = 30
     }
     
     private let titleLabel = UILabel().then {
-        $0.font = .light(size: 24)
-        $0.textColor = Color.black
+        $0.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 20)
+        $0.textColor = DesignSystemAsset.Colors.gray100.color
         $0.attributedText = NSMutableAttributedString(
             string: "write_address_confirm_popup_title".localized,
-            attributes: [.kern: -0.5]
+            attributes: [.kern: -1]
         )
-        $0.numberOfLines = 0
+        $0.numberOfLines = 2
     }
     
     let closeButton = UIButton().then {
@@ -25,96 +27,101 @@ final class AddressConfirmPopupView: BaseView {
     }
     
     private let descriptionLabel = UILabel().then {
-        $0.text = "write_address_confirm_popup_description".localized
-        $0.font = .semiBold(size: 14)
-        $0.textColor = Color.gray50
+        $0.font = DesignSystemFontFamily.Pretendard.medium.font(size: 12)
+        $0.textColor = DesignSystemAsset.Colors.gray50.color
+        
+        let text = "write_address_confirm_popup_description".localized
+        let attributedText = NSMutableAttributedString(string: text)
+        let range = (text as NSString).range(of: "중복된 가게 제보")
+        
+        attributedText.addAttribute(.foregroundColor, value: DesignSystemAsset.Colors.gray80.color, range: range)
+        $0.attributedText = attributedText
     }
     
     private let addressContainerView = UIView().then {
-        $0.backgroundColor = Color.gray0
-        $0.layer.cornerRadius = 8
+        $0.backgroundColor = DesignSystemAsset.Colors.gray10.color
+        $0.layer.cornerRadius = 12
     }
     
     private let addressLabel = UILabel().then {
-        $0.textColor = Color.gray100
-        $0.font = .semiBold(size: 16)
+        $0.textColor = DesignSystemAsset.Colors.gray70.color
+        $0.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
         $0.textAlignment = .center
     }
     
     let okButton = UIButton().then {
-        $0.layer.cornerRadius = 24
-        $0.backgroundColor = Color.red
-        $0.titleLabel?.font = .bold(size: 16)
-        $0.setTitleColor(.white, for: .normal)
+        $0.layer.cornerRadius = 12
+        $0.backgroundColor = DesignSystemAsset.Colors.mainPink.color
+        $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 14)
+        $0.setTitleColor(DesignSystemAsset.Colors.systemWhite.color, for: .normal)
         $0.setTitle("write_address_confirm_popup_ok".localized, for: .normal)
     }
     
     override func setup() {
-        self.backgroundColor = .clear
-        self.backgroundView.addGestureRecognizer(self.tapBackground)
-        self.addSubViews([
-            self.backgroundView,
-            self.containerView,
-            self.titleLabel,
-            self.closeButton,
-            self.descriptionLabel,
-            self.addressContainerView,
-            self.addressLabel,
-            self.okButton
+        backgroundColor = .clear
+        backgroundView.addGestureRecognizer(tapBackground)
+        addSubViews([
+            backgroundView,
+            containerView,
+            titleLabel,
+            closeButton,
+            descriptionLabel,
+            addressContainerView,
+            addressLabel,
+            okButton
         ])
     }
     
     override func bindConstraints() {
-        self.backgroundView.snp.makeConstraints { make in
+        backgroundView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
         
-        self.containerView.snp.makeConstraints { make in
-            make.left.equalToSuperview().offset(24)
-            make.right.equalToSuperview().offset(-24)
-            make.top.equalTo(self.titleLabel).offset(-32)
-            make.bottom.equalTo(safeAreaLayoutGuide).offset(-20)
+        containerView.snp.makeConstraints { make in
+            make.left.equalToSuperview()
+            make.right.equalToSuperview()
+            make.top.equalTo(titleLabel).offset(-26)
+            make.bottom.equalToSuperview()
         }
         
-        self.okButton.snp.makeConstraints { make in
-            make.left.equalTo(self.containerView).offset(12)
-            make.right.equalTo(self.containerView).offset(-12)
+        okButton.snp.makeConstraints { make in
+            make.left.equalTo(containerView).offset(20)
+            make.right.equalTo(containerView).offset(-20)
             make.height.equalTo(48)
-            make.bottom.equalTo(self.containerView).offset(-32)
+            make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-12)
         }
         
-        self.addressContainerView.snp.makeConstraints { make in
-            make.left.equalTo(self.containerView).offset(12)
-            make.right.equalTo(self.containerView).offset(-12)
-            make.bottom.equalTo(self.okButton.snp.top).offset(-16)
+        addressContainerView.snp.makeConstraints { make in
+            make.left.equalTo(containerView).offset(20)
+            make.right.equalTo(containerView).offset(-20)
+            make.bottom.equalTo(okButton.snp.top).offset(-21)
             make.height.equalTo(48)
         }
         
-        self.addressLabel.snp.makeConstraints { make in
-            make.left.equalTo(self.addressContainerView).offset(12)
-            make.right.equalTo(self.addressContainerView).offset(-12)
-            make.centerY.equalTo(self.addressContainerView)
+        addressLabel.snp.makeConstraints { make in
+            make.left.equalTo(addressContainerView).offset(12)
+            make.right.equalTo(addressContainerView).offset(-12)
+            make.centerY.equalTo(addressContainerView)
         }
         
-        self.descriptionLabel.snp.makeConstraints { make in
-            make.left.equalTo(self.containerView).offset(24)
-            make.bottom.equalTo(self.addressContainerView.snp.top).offset(-24)
+        descriptionLabel.snp.makeConstraints { make in
+            make.left.equalTo(containerView).offset(20)
+            make.bottom.equalTo(addressContainerView.snp.top).offset(-20)
         }
         
-        self.titleLabel.snp.makeConstraints { make in
-            make.left.equalTo(self.containerView).offset(24)
-            make.right.equalTo(self.closeButton.snp.left).offset(-12)
-            make.bottom.equalTo(self.descriptionLabel.snp.top).offset(-12)
+        titleLabel.snp.makeConstraints { make in
+            make.left.equalTo(containerView).offset(20)
+            make.bottom.equalTo(descriptionLabel.snp.top).offset(-8)
         }
         
-        self.closeButton.snp.makeConstraints { make in
-            make.top.equalTo(self.containerView).offset(32)
-            make.right.equalTo(self.containerView).offset(-24)
+        closeButton.snp.makeConstraints { make in
+            make.top.equalTo(containerView).offset(26)
+            make.right.equalTo(containerView).offset(-20)
             make.width.height.equalTo(24)
         }
     }
     
     func bind(address: String) {
-        self.addressLabel.text = address
+        addressLabel.text = address
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupView.swift
@@ -3,9 +3,7 @@ import UIKit
 import DesignSystem
 
 final class AddressConfirmPopupView: BaseView {
-    let tapBackground = UITapGestureRecognizer()
-    
-    private let backgroundView = UIView()
+    let backgroundView = UIView()
     
     private let containerView = UIView().then {
         $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
@@ -59,7 +57,6 @@ final class AddressConfirmPopupView: BaseView {
     
     override func setup() {
         backgroundColor = .clear
-        backgroundView.addGestureRecognizer(tapBackground)
         addSubViews([
             backgroundView,
             containerView,

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupView.swift
@@ -8,6 +8,7 @@ final class AddressConfirmPopupView: BaseView {
     private let containerView = UIView().then {
         $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         $0.layer.cornerRadius = 30
+        $0.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
     }
     
     private let titleLabel = UILabel().then {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupViewController.swift
@@ -1,26 +1,22 @@
 import Foundation
 
 protocol AddressConfirmPopupViewControllerDelegate: AnyObject {
-    func onDismiss()
-    
     func onClickOk()
 }
 
-final class AddressConfirmPopupViewController: BaseVC, AddressConfirmPopupCoordinator {
+final class AddressConfirmPopupViewController: BaseBottomSheetViewController, AddressConfirmPopupCoordinator {
     weak var delegate: AddressConfirmPopupViewControllerDelegate?
     private let addressConfirmPopupView = AddressConfirmPopupView()
     private weak var coordinator: AddressConfirmPopupCoordinator?
     
     static func instacne(address: String) -> AddressConfirmPopupViewController {
-        return AddressConfirmPopupViewController(address: address).then {
-            $0.modalPresentationStyle = .overCurrentContext
-        }
+        return AddressConfirmPopupViewController(address: address)
     }
     
     init(address: String) {
         super.init(nibName: nil, bundle: nil)
         
-        self.addressConfirmPopupView.bind(address: address)
+        addressConfirmPopupView.bind(address: address)
     }
     
     required init?(coder: NSCoder) {
@@ -28,38 +24,40 @@ final class AddressConfirmPopupViewController: BaseVC, AddressConfirmPopupCoordi
     }
     
     override func loadView() {
-        self.view = self.addressConfirmPopupView
+        view = addressConfirmPopupView
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.coordinator = self
+        coordinator = self
     }
     
     override func bindEvent() {
-        self.addressConfirmPopupView.tapBackground.rx.event
-            .asDriver()
-            .drive(onNext: { [weak self] _ in
-                self?.coordinator?.dismiss()
-                self?.delegate?.onDismiss()
-            })
-            .disposed(by: self.eventDisposeBag)
+        addressConfirmPopupView.backgroundView
+            .gesture(.tap())
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.coordinator?.dismiss()
+            }
+            .store(in: &cancellables)
         
-        self.addressConfirmPopupView.closeButton.rx.tap
-            .asDriver()
-            .drive(onNext: { [weak self] _ in
-                self?.coordinator?.dismiss()
-                self?.delegate?.onDismiss()
-            })
-            .disposed(by: self.eventDisposeBag)
+        addressConfirmPopupView.closeButton
+            .controlPublisher(for: .touchUpInside)
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.coordinator?.dismiss()
+            }
+            .store(in: &cancellables)
         
-        self.addressConfirmPopupView.okButton.rx.tap
-            .asDriver()
-            .drive(onNext: { [weak self] in
-                self?.coordinator?.dismiss()
-                self?.delegate?.onClickOk()
+        addressConfirmPopupView.okButton
+            .controlPublisher(for: .touchUpInside)
+            .withUnretained(self)
+            .sink(receiveValue: { owner, _ in
+                owner.coordinator?.dismiss(completion: {
+                    owner.delegate?.onClickOk()
+                })
             })
-            .disposed(by: self.eventDisposeBag)
+            .store(in: &cancellables)
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/address-comfirm-popup/AddressConfirmPopupViewModel.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Combine
+
+final class AddressConfirmPopupViewModel {
+    struct Input {
+        let viewDidLoad = PassthroughSubject<Void, Never>()
+        let tapOk = PassthroughSubject<Void, Never>()
+    }
+    
+    struct Output {
+        let address = PassthroughSubject<String, Never>()
+        let route = PassthroughSubject<Route, Never>()
+    }
+    
+    enum Route {
+        case dismiss
+    }
+    
+    private struct State {
+        let address: String
+    }
+    
+    let input = Input()
+    let output = Output()
+    private let state: State
+    private var cancellables = Set<AnyCancellable>()
+    private let analyticsManager: AnalyticsManagerProtocol
+    
+    init(
+        address: String,
+        analyticsManager: AnalyticsManagerProtocol = AnalyticsManager.shared
+    ) {
+        self.state = State(address: address)
+        self.analyticsManager = analyticsManager
+        
+        bind()
+    }
+    
+    private func bind() {
+        input.viewDidLoad
+            .withUnretained(self)
+            .handleEvents(receiveOutput: { owner, _ in
+                owner.sendPageViewLog()
+            })
+            .map { owner, _ in
+                owner.state.address
+            }
+            .subscribe(output.address)
+            .store(in: &cancellables)
+        
+        input.tapOk
+            .withUnretained(self)
+            .handleEvents(receiveOutput: { owner, _ in
+                owner.sendClickOkLog(address: owner.state.address)
+            })
+            .map { owner, _ in
+                Route.dismiss
+            }
+            .subscribe(output.route)
+            .store(in: &cancellables)
+    }
+    
+    private func sendPageViewLog() {
+        analyticsManager.logPageView(screen: .writeAddressPopup, type: AddressConfirmPopupViewController.self)
+    }
+    
+    private func sendClickOkLog(address: String) {
+        analyticsManager.logEvent(event: .clickAddressOk(address: address), screen: .writeAddressPopup)
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/extension/UIGestureExtension.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/extension/UIGestureExtension.swift
@@ -1,0 +1,82 @@
+import UIKit
+import Combine
+
+extension UIGestureRecognizer {
+    struct GesturePublisher: Publisher {
+        typealias Output = GestureType
+        typealias Failure = Never
+        
+        private let view: UIView
+        private let gestureType: GestureType
+        
+        init(view: UIView, gestureType: GestureType) {
+            self.view = view
+            self.gestureType = gestureType
+        }
+        
+        func receive<S>(subscriber: S) where S : Subscriber,
+                                             GesturePublisher.Failure == S.Failure, GesturePublisher.Output
+                                                 == S.Input {
+            let subscription = GestureSubscription(
+                subscriber: subscriber,
+                view: view,
+                gestureType: gestureType
+            )
+            subscriber.receive(subscription: subscription)
+        }
+    }
+    
+    class GestureSubscription<S: Subscriber>: Subscription where S.Input == GestureType, S.Failure == Never {
+        private var subscriber: S?
+        private var gestureType: GestureType
+        private var view: UIView
+        
+        init(subscriber: S, view: UIView, gestureType: GestureType) {
+            self.subscriber = subscriber
+            self.view = view
+            self.gestureType = gestureType
+            configureGesture(gestureType)
+        }
+        
+        private func configureGesture(_ gestureType: GestureType) {
+            let gesture = gestureType.get()
+            gesture.addTarget(self, action: #selector(handler))
+            view.addGestureRecognizer(gesture)
+        }
+        
+        func request(_ demand: Subscribers.Demand) { }
+        
+        func cancel() {
+            subscriber = nil
+        }
+        
+        @objc private func handler() {
+            _ = subscriber?.receive(gestureType)
+        }
+    }
+    
+    enum GestureType {
+        case tap(UITapGestureRecognizer = .init())
+        case swipe(UISwipeGestureRecognizer = .init())
+        case longPress(UILongPressGestureRecognizer = .init())
+        case pan(UIPanGestureRecognizer = .init())
+        case pinch(UIPinchGestureRecognizer = .init())
+        case edge(UIScreenEdgePanGestureRecognizer = .init())
+        func get() -> UIGestureRecognizer {
+            switch self {
+            case let .tap(tapGesture):
+                return tapGesture
+            case let .swipe(swipeGesture):
+                return swipeGesture
+            case let .longPress(longPressGesture):
+                return longPressGesture
+            case let .pan(panGesture):
+                return panGesture
+            case let .pinch(pinchGesture):
+                return pinchGesture
+            case let .edge(edgePanGesture):
+                return edgePanGesture
+            }
+        }
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/extension/UIViewExtension.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/extension/UIViewExtension.swift
@@ -13,4 +13,8 @@ extension UIView {
             self.addSubview(view)
         }
     }
+    
+    func gesture(_ type: UIGestureRecognizer.GestureType) -> UIGestureRecognizer.GesturePublisher {
+        return .init(view: self, gestureType: type)
+    }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/manager/DimManager.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/manager/DimManager.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+import DesignSystem
+
 final class DimManager {
     static let shared = DimManager()
     
@@ -10,7 +12,7 @@ final class DimManager {
         targetView.addSubview(self.dimView)
         
         UIView.animate(withDuration: 0.3) { [weak self] in
-            self?.dimView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+            self?.dimView.backgroundColor = DesignSystemAsset.Colors.systemBlack.color.withAlphaComponent(0.8)
         }
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsEvent.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsEvent.swift
@@ -12,6 +12,7 @@ enum AnalyticsEvent {
     
     /// write-address 제보주소화면
     case clickSetAddress(address: String)
+    case clickAddressOk(address: String)
     
     var name: String {
         switch self {
@@ -38,6 +39,9 @@ enum AnalyticsEvent {
             
         case .clickSetAddress:
             return "click_set_address"
+            
+        case .clickAddressOk:
+            return "click_address_ok"
         }
     }
     
@@ -65,6 +69,9 @@ enum AnalyticsEvent {
             return [:]
             
         case .clickSetAddress(let address):
+            return ["address": address]
+            
+        case .clickAddressOk(let address):
             return ["address": address]
         }
     }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsScreen.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsScreen.swift
@@ -12,4 +12,5 @@ enum AnalyticsScreen: String {
     
     /// 제보 주소 화면
     case writeAddress = "write_address"
+    case writeAddressPopup = "write_address_popop"
 }


### PR DESCRIPTION
### 변경사항
- WriteAddressConfirm
    - 디자인 시스템으로 뷰 리터칭
    - 디자인 변경사항 적용
    - ViewModel 생성
    - 로그 추가

### 테스트
- 시뮬, 디바이스 모두 가능합니다.

<img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/assets/7058293/2e6953af-4197-4d59-8e18-6536fe64e8ee" width=360>



### 테스트 케이스
- 입력한 주소가 그대로 나오는가?
- 여기가 확실해요 버튼 터치 시, 상세 제보 화면으로 이동하는가?
- 닫기 버튼 터치 시 바텀시트가 닫히는가?
- 바텀시트 위에 배경 터치 시, 바텀시트가 닫히는가?

### ⚠️ 주의사항
- 기본적인 아키텍처 적용건은 이전 PR에서 구현해서 해당 코드를 참고로 작업해주시면됩니다!
- 저는 작업 하는대로 PR 만들어두고 머지할께요!! 참고용으로만 봐주셔도 좋습니다 👍