### PR TITLE
카테고리 선택 화면

### DIFF
--- a/App/Derived/Sources/TuistStrings+ThreeDollarInMyPocket.swift
+++ b/App/Derived/Sources/TuistStrings+ThreeDollarInMyPocket.swift
@@ -12,14 +12,10 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 public enum ThreeDollarInMyPocketStrings {
-  /// 다중선택 가능
-  public static let addCategoryMulti = ThreeDollarInMyPocketStrings.tr("Localization", "add_category_multi")
   /// 총 %d개 선택하기
   public static func addCategoryNumberFormat(_ p1: Int) -> String {
     return ThreeDollarInMyPocketStrings.tr("Localization", "add_category_number_format", p1)
   }
-  /// 카테고리 선택
-  public static let addCategoryTitle = ThreeDollarInMyPocketStrings.tr("Localization", "add_category_title")
   /// 리스트에 대한 한줄평을 입력해주세요! 공유 시 사용됩니다.
   public static let bookmarkEditPlaceholderDescription = ThreeDollarInMyPocketStrings.tr("Localization", "bookmark_edit_placeholder_description")
   /// 저장하기
@@ -156,6 +152,12 @@ public enum ThreeDollarInMyPocketStrings {
   public static let categoryOrderingDistance = ThreeDollarInMyPocketStrings.tr("Localization", "category_ordering_distance")
   /// 별점순
   public static let categoryOrderingReview = ThreeDollarInMyPocketStrings.tr("Localization", "category_ordering_review")
+  /// * 다중선택 가능
+  public static let categorySelectionMulti = ThreeDollarInMyPocketStrings.tr("Localization", "category_selection_multi")
+  /// 카테고리 선택 완료
+  public static let categorySelectionOk = ThreeDollarInMyPocketStrings.tr("Localization", "category_selection_ok")
+  /// 카테고리 선택
+  public static let categorySelectionTitle = ThreeDollarInMyPocketStrings.tr("Localization", "category_selection_title")
   /// 만나기 30초 전
   public static let categorySubTextBungeoppang = ThreeDollarInMyPocketStrings.tr("Localization", "category_sub_text_bungeoppang")
   /// 내 입으로

--- a/App/Targets/three-dollar-in-my-pocket/Resources/en.lproj/Localization.strings
+++ b/App/Targets/three-dollar-in-my-pocket/Resources/en.lproj/Localization.strings
@@ -119,8 +119,6 @@
 "write_store_saturday" = "토";
 "write_store_add_category" = "추가하기";
 "write_store_menu" = "상세 메뉴";
-"add_category_title" = "카테고리 선택";
-"add_category_multi" = "다중선택 가능";
 "add_category_number_format" = "총 %d개 선택하기";
 "write_store_register_button" = "가게 등록하기";
 "shared_category_bungeoppang" = "붕어빵";
@@ -304,6 +302,11 @@
 "write_detail_header_delete_all_menu" = "전체 삭제";
 "write_detail_store_option" = "(선택)";
 "write_detail_store_can_select_multi" = "*다중선택 가능";
+
+// 카테고리 선택 화면
+"category_selection_title" = "카테고리 선택";
+"category_selection_multi" = "* 다중선택 가능";
+"category_selection_ok" = "카테고리 선택 완료";
 
 // 공통
 "store_type_road" = "길거리";

--- a/App/Targets/three-dollar-in-my-pocket/Resources/ko.lproj/Localization.strings
+++ b/App/Targets/three-dollar-in-my-pocket/Resources/ko.lproj/Localization.strings
@@ -119,8 +119,6 @@
 "write_store_saturday" = "토";
 "write_store_add_category" = "추가하기";
 "write_store_menu" = "상세 메뉴";
-"add_category_title" = "카테고리 선택";
-"add_category_multi" = "다중선택 가능";
 "add_category_number_format" = "총 %d개 선택하기";
 "write_store_register_button" = "가게 등록하기";
 "shared_category_bungeoppang" = "붕어빵";
@@ -304,6 +302,11 @@
 "write_detail_header_delete_all_menu" = "전체 삭제";
 "write_detail_store_option" = "(선택)";
 "write_detail_store_can_select_multi" = "*다중선택 가능";
+
+// 카테고리 선택 화면
+"category_selection_title" = "카테고리 선택";
+"category_selection_multi" = "* 다중선택 가능";
+"category_selection_ok" = "카테고리 선택 완료";
 
 // 공통
 "store_type_road" = "길거리";

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionCell.swift
@@ -1,0 +1,59 @@
+import UIKit
+
+import DesignSystem
+
+final class CategorySelectionCell: BaseCollectionViewCell {
+    enum Layout {
+        static let imageWidth: CGFloat = (UIScreen.main.bounds.width - 40 - 64)/5
+        static let size = CGSize(width: imageWidth, height: imageWidth + 22)
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            categoryButton.layer.borderColor = isSelected ? DesignSystemAsset.Colors.mainPink.color.cgColor : DesignSystemAsset.Colors.gray30.color.cgColor
+        }
+    }
+    
+    let categoryButton = UIButton().then {
+        $0.isUserInteractionEnabled = false
+        $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
+        $0.layer.cornerRadius = Layout.imageWidth / 2
+        $0.layer.masksToBounds = true
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = DesignSystemAsset.Colors.gray30.color.cgColor
+        $0.contentEdgeInsets = .init(top: 10, left: 10, bottom: 10, right: 10)
+    }
+    
+    let titleLabel = UILabel().then {
+        $0.font = DesignSystemFontFamily.Pretendard.medium.font(size: 12)
+        $0.textColor = DesignSystemAsset.Colors.gray90.color
+        $0.textAlignment = .center
+    }
+    
+    override func setup() {
+        contentView.addSubViews([
+            categoryButton,
+            titleLabel
+        ])
+    }
+    
+    override func bindConstraints() {
+        categoryButton.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.width.height.equalTo(Layout.imageWidth)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.left.equalToSuperview()
+            $0.right.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+    func bind(category: PlatformStoreCategory) {
+        titleLabel.text = category.name
+        categoryButton.setImage(urlString: category.disableImageUrl, state: .normal)
+        categoryButton.setImage(urlString: category.imageUrl, state: .selected)
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionCoordinator.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionCoordinator.swift
@@ -1,0 +1,13 @@
+protocol CategorySelectionCoordinator: AnyObject, BaseCoordinator {
+    func handleRoute(route: CategorySelectionViewModel.Route)
+}
+
+extension CategorySelectionCoordinator where Self: CategorySelectionViewController {
+    func handleRoute(route: CategorySelectionViewModel.Route) {
+        switch route {
+        case .dismissWithCategories(let selectedCategories):
+            delegate?.onSelectCategories(categories: selectedCategories)
+            dismiss()
+        }
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionDataSource.swift
@@ -1,0 +1,47 @@
+import UIKit
+
+final class CategorySelectionDataSource: UICollectionViewDiffableDataSource<CategorySelectionSection, CategorySelectionItem> {
+    let viewModel: CategorySelectionViewModel
+    
+    init(collectionView: UICollectionView, viewModel: CategorySelectionViewModel) {
+        self.viewModel = viewModel
+        super.init(collectionView: collectionView) { collectionView, indexPath, itemIdentifier in
+            switch itemIdentifier {
+            case .category(let category):
+                let cell: CategorySelectionCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                
+                cell.bind(category: category)
+                return cell
+            }
+        }
+        
+        collectionView.register([
+            CategorySelectionCell.self
+        ])
+        collectionView.delegate = self
+    }
+}
+
+extension CategorySelectionDataSource: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        viewModel.input.selectCategory.send(indexPath.row)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        viewModel.input.deSelectCategory.send(indexPath.row)
+    }
+}
+
+
+struct CategorySelectionSection: Hashable {
+    enum SectionType: Hashable {
+        case category
+    }
+    
+    let type: SectionType
+    var items: [CategorySelectionItem]
+}
+
+enum CategorySelectionItem: Hashable {
+    case category(PlatformStoreCategory)
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionView.swift
@@ -1,0 +1,109 @@
+import UIKit
+
+import DesignSystem
+
+final class CategorySelectionView: BaseView {
+    enum Layout {
+        static let itemSpace: CGFloat = 16
+        static let lineSpace: CGFloat = 12
+    }
+    
+    let backgroundButton = UIButton()
+    
+    private let containerView = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 24
+        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+    }
+    
+    private let titleLabel = UILabel().then {
+        $0.text = ThreeDollarInMyPocketStrings.categorySelectionTitle
+        $0.textColor = DesignSystemAsset.Colors.gray100.color
+        $0.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 20)
+    }
+    
+    private let multiLabel = UILabel().then {
+        $0.text = ThreeDollarInMyPocketStrings.categorySelectionMulti
+        $0.textColor = DesignSystemAsset.Colors.mainPink.color
+        $0.font = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
+    }
+    
+    lazy var categoryCollectionView = UICollectionView(
+      frame: .zero,
+      collectionViewLayout: generateLayout()
+    ).then {
+      $0.backgroundColor = .clear
+      $0.showsVerticalScrollIndicator = false
+      $0.showsHorizontalScrollIndicator = false
+    }
+    
+    let selectButton = UIButton().then {
+        $0.layer.cornerRadius = 12
+        $0.backgroundColor = DesignSystemAsset.Colors.gray30.color
+        $0.setTitle(ThreeDollarInMyPocketStrings.categorySelectionOk, for: .normal)
+        $0.setTitleColor(DesignSystemAsset.Colors.systemWhite.color, for: .normal)
+        $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 14)
+    }
+    
+    override func setup() {
+        backgroundColor = .clear
+        addSubViews([
+            backgroundButton,
+            containerView,
+            titleLabel,
+            multiLabel,
+            categoryCollectionView,
+            selectButton
+        ])
+    }
+    
+    override func bindConstraints() {
+        backgroundButton.snp.makeConstraints {
+            $0.left.equalToSuperview()
+            $0.right.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.bottom.equalTo(containerView.snp.top)
+        }
+        
+        containerView.snp.makeConstraints {
+            $0.left.equalToSuperview()
+            $0.right.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.top.equalTo(titleLabel).offset(-24)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(20)
+            $0.bottom.equalTo(categoryCollectionView.snp.top).offset(-17)
+        }
+        
+        multiLabel.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel)
+            $0.left.equalTo(titleLabel.snp.right).offset(12)
+        }
+        
+        categoryCollectionView.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(20)
+            $0.right.equalToSuperview().offset(-20)
+            $0.bottom.equalTo(selectButton.snp.top).offset(-28)
+            $0.height.equalTo(0)
+        }
+        
+        selectButton.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(20)
+            $0.right.equalToSuperview().offset(-20)
+            $0.bottom.equalTo(safeAreaLayoutGuide).offset(-20)
+            $0.height.equalTo(48)
+        }
+    }
+    
+    private func generateLayout() -> UICollectionViewFlowLayout {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.itemSize = CGSize(width: 52, height: 72)
+        layout.minimumInteritemSpacing = Layout.itemSpace
+        layout.minimumLineSpacing = Layout.lineSpace
+        
+        return layout
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionView.swift
@@ -29,20 +29,24 @@ final class CategorySelectionView: BaseView {
     }
     
     lazy var categoryCollectionView = UICollectionView(
-      frame: .zero,
-      collectionViewLayout: generateLayout()
+        frame: .zero,
+        collectionViewLayout: generateLayout()
     ).then {
-      $0.backgroundColor = .clear
-      $0.showsVerticalScrollIndicator = false
-      $0.showsHorizontalScrollIndicator = false
+        $0.backgroundColor = .clear
+        $0.showsVerticalScrollIndicator = false
+        $0.showsHorizontalScrollIndicator = false
+        $0.allowsMultipleSelection = true
     }
     
     let selectButton = UIButton().then {
         $0.layer.cornerRadius = 12
-        $0.backgroundColor = DesignSystemAsset.Colors.gray30.color
+        $0.layer.masksToBounds = true
         $0.setTitle(ThreeDollarInMyPocketStrings.categorySelectionOk, for: .normal)
         $0.setTitleColor(DesignSystemAsset.Colors.systemWhite.color, for: .normal)
+        $0.setBackgroundColor(DesignSystemAsset.Colors.gray30.color, for: .disabled)
+        $0.setBackgroundColor(DesignSystemAsset.Colors.mainPink.color, for: .normal)
         $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 14)
+        $0.isEnabled = false
     }
     
     override func setup() {
@@ -97,10 +101,20 @@ final class CategorySelectionView: BaseView {
         }
     }
     
+    func updateCollectionViewHeight(itemCount: Int) {
+        let row = CGFloat(itemCount / 5 + 1)
+        let height = (CategorySelectionCell.Layout.size.height * row) + (Layout.lineSpace * (row - 1))
+        
+        categoryCollectionView.snp.updateConstraints {
+            $0.height.equalTo(height)
+        }
+        layoutIfNeeded()
+    }
+    
     private func generateLayout() -> UICollectionViewFlowLayout {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
-        layout.itemSize = CGSize(width: 52, height: 72)
+        layout.itemSize = CategorySelectionCell.Layout.size
         layout.minimumInteritemSpacing = Layout.itemSpace
         layout.minimumLineSpacing = Layout.lineSpace
         

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionView.swift
@@ -38,14 +38,7 @@ final class CategorySelectionView: BaseView {
         $0.allowsMultipleSelection = true
     }
     
-    let selectButton = UIButton().then {
-        $0.layer.cornerRadius = 12
-        $0.layer.masksToBounds = true
-        $0.setTitle(ThreeDollarInMyPocketStrings.categorySelectionOk, for: .normal)
-        $0.setTitleColor(DesignSystemAsset.Colors.systemWhite.color, for: .normal)
-        $0.setBackgroundColor(DesignSystemAsset.Colors.gray30.color, for: .disabled)
-        $0.setBackgroundColor(DesignSystemAsset.Colors.mainPink.color, for: .normal)
-        $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 14)
+    let selectButton = Button.Normal(size: .h52, text: ThreeDollarInMyPocketStrings.categorySelectionOk).then {
         $0.isEnabled = false
     }
     
@@ -97,7 +90,6 @@ final class CategorySelectionView: BaseView {
             $0.left.equalToSuperview().offset(20)
             $0.right.equalToSuperview().offset(-20)
             $0.bottom.equalTo(safeAreaLayoutGuide).offset(-20)
-            $0.height.equalTo(48)
         }
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionViewController.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+final class CategorySelectionViewController: BaseBottomSheetViewController {
+    private let categorySelectionView = CategorySelectionView()
+    
+    static func instance() -> CategorySelectionViewController {
+        return CategorySelectionViewController(nibName: nil, bundle: nil)
+    }
+    
+    override func loadView() {
+        view = categorySelectionView
+    }
+    
+    override func bindEvent() {
+        categorySelectionView.backgroundButton
+            .controlPublisher(for: .touchUpInside)
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.dismiss()
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionViewController.swift
@@ -1,7 +1,17 @@
 import UIKit
 
-final class CategorySelectionViewController: BaseBottomSheetViewController {
+typealias CategorySelectionSnapshot = NSDiffableDataSourceSnapshot<CategorySelectionSection, CategorySelectionItem>
+
+protocol CategorySelectionDelegate: AnyObject {
+    func onSelectCategories(categories: [PlatformStoreCategory])
+}
+
+final class CategorySelectionViewController: BaseBottomSheetViewController, CategorySelectionCoordinator {
+    weak var delegate: CategorySelectionDelegate?
     private let categorySelectionView = CategorySelectionView()
+    private let viewModel = CategorySelectionViewModel()
+    private weak var coordinator: CategorySelectionCoordinator?
+    private lazy var dataSource = CategorySelectionDataSource(collectionView: categorySelectionView.categoryCollectionView, viewModel: viewModel)
     
     static func instance() -> CategorySelectionViewController {
         return CategorySelectionViewController(nibName: nil, bundle: nil)
@@ -11,12 +21,71 @@ final class CategorySelectionViewController: BaseBottomSheetViewController {
         view = categorySelectionView
     }
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        coordinator = self
+        viewModel.input.viewDidLoad.send(())
+    }
+    
     override func bindEvent() {
         categorySelectionView.backgroundButton
             .controlPublisher(for: .touchUpInside)
             .withUnretained(self)
             .sink { owner, _ in
                 owner.dismiss()
+            }
+            .store(in: &cancellables)
+    }
+    
+    override func bindViewModelInput() {
+        categorySelectionView.selectButton
+            .controlPublisher(for: .touchUpInside)
+            .mapVoid
+            .subscribe(viewModel.input.tapSelect)
+            .store(in: &cancellables)
+    }
+    
+    override func bindViewModelOutput() {
+        viewModel.output.categories
+            .map { categories in
+                CategorySelectionSection(
+                    type: .category,
+                    items: categories.map { .category($0) }
+                )
+            }
+            .withUnretained(self)
+            .receive(on: DispatchQueue.main)
+            .handleEvents(receiveOutput: { owner, section in
+                owner.categorySelectionView.updateCollectionViewHeight(itemCount: section.items.count)
+            })
+            .sink { owner, section in
+                var snapshot = CategorySelectionSnapshot()
+                snapshot.appendSections([section])
+                snapshot.appendItems(section.items)
+                
+                owner.dataSource.apply(snapshot, animatingDifferences: true)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.output.isEnableSelectButton
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.isEnabled, on: categorySelectionView.selectButton)
+            .store(in: &cancellables)
+        
+        viewModel.output.error
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, error in
+                owner.coordinator?.showErrorAlert(error: error)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.output.route
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, route in
+                owner.coordinator?.handleRoute(route: route)
             }
             .store(in: &cancellables)
     }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionViewModel.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Combine
+
+import Networking
+import Common
+
+final class CategorySelectionViewModel {
+    struct Input {
+        let viewDidLoad = PassthroughSubject<Void, Never>()
+        let selectCategory = PassthroughSubject<Int, Never>()
+        let deSelectCategory = PassthroughSubject<Int, Never>()
+        let tapSelect = PassthroughSubject<Int, Never>()
+    }
+    
+    struct Output {
+        let categories = PassthroughSubject<[Networking.PlatformStoreCategoryResponse], Never>()
+        let error = PassthroughSubject<Error, Never>()
+        let route = PassthroughSubject<Route, Never>()
+    }
+    
+    enum Route {
+        case dismissWithCategories([Networking.PlatformStoreCategoryResponse])
+    }
+    
+    private struct State {
+        var categories: [Networking.PlatformStoreCategoryResponse] = []
+        var selectedCategories: [Networking.PlatformStoreCategoryResponse] = []
+    }
+    
+    let input = Input()
+    let output = Output()
+    private var state = State()
+    private var cancellables = Set<AnyCancellable>()
+    private let categoryService: Networking.CategoryServiceProtocol
+    private let analyticsManager: AnalyticsManagerProtocol
+    
+    init(
+        categoryService: Networking.CategoryServiceProtocol = Networking.CategoryService(),
+        analyticsManager: AnalyticsManagerProtocol = AnalyticsManager.shared
+    ) {
+        self.categoryService = categoryService
+        self.analyticsManager = analyticsManager
+        
+        bind()
+    }
+    
+    private func bind() {
+        input.viewDidLoad
+            .withUnretained(self)
+            .handleEvents(receiveOutput: { owner, _ in
+                // 페이지 뷰
+            })
+            .asyncMap { owner, _ in
+                await owner.categoryService.fetchCategoires()
+            }
+            .withUnretained(self)
+            .sink { owner, result in
+                switch result {
+                case .success(let categories):
+                    owner.state.categories = categories
+                    owner.output.categories.send(categories)
+                    
+                case .failure(let error):
+                    owner.output.error.send(error)
+                }
+            }
+            .store(in: &cancellables)
+        
+        input.selectCategory
+            .withUnretained(self)
+            .sink { owner, index in
+                guard let selectedCategory = owner.state.categories[safe: index] else { return }
+                
+                owner.state.selectedCategories.append(selectedCategory)
+            }
+            .store(in: &cancellables)
+        
+        input.deSelectCategory
+            .withUnretained(self)
+            .sink { owner, index in
+                guard let selectedCategory = owner.state.categories[safe: index],
+                      let targetIndex = owner.state.selectedCategories.firstIndex(where: { $0.categoryId == selectedCategory.categoryId })
+                else { return }
+                
+                owner.state.selectedCategories.remove(at: targetIndex)
+            }
+            .store(in: &cancellables)
+        
+        input.tapSelect
+            .withUnretained(self)
+            .map { owner, _ in
+                Route.dismissWithCategories(owner.state.selectedCategories)
+            }
+            .subscribe(output.route)
+            .store(in: &cancellables)
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/add-category/CategorySelectionViewModel.swift
@@ -48,7 +48,7 @@ final class CategorySelectionViewModel {
         input.viewDidLoad
             .withUnretained(self)
             .handleEvents(receiveOutput: { owner, _ in
-                // 페이지 뷰
+                owner.sendPageViewLog()
             })
             .asyncMap { owner, _ in
                 await owner.categoryService.fetchCategoires()
@@ -92,10 +92,23 @@ final class CategorySelectionViewModel {
         
         input.tapSelect
             .withUnretained(self)
+            .handleEvents(receiveOutput: { owner, _ in
+                let selectedCategoryIds = owner.state.selectedCategories.map { $0.id }
+                
+                owner.sendClickCategoryLog(categoryIds: selectedCategoryIds)
+            })
             .map { owner, _ in
                 Route.dismissWithCategories(owner.state.selectedCategories)
             }
             .subscribe(output.route)
             .store(in: &cancellables)
+    }
+    
+    private func sendPageViewLog() {
+        analyticsManager.logPageView(screen: .categorySelection, type: CategorySelectionViewController.self)
+    }
+    
+    private func sendClickCategoryLog(categoryIds: [String]) {
+        analyticsManager.logEvent(event: .clickSelectCategory(categoryIds: categoryIds), screen: .categorySelection)
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/extension/ArrayExtension.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/extension/ArrayExtension.swift
@@ -4,4 +4,8 @@ extension Array {
     subscript (safe index: Int) -> Element? {
         return indices ~= index ? self[index] : nil
     }
+    
+    var isNotEmpty: Bool {
+        return !self.isEmpty
+    }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsEvent.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsEvent.swift
@@ -14,6 +14,9 @@ enum AnalyticsEvent {
     case clickSetAddress(address: String)
     case clickAddressOk(address: String)
     
+    /// category-selection 카테고리 선택 화면
+    case clickSelectCategory(categoryIds: [String])
+    
     var name: String {
         switch self {
         case .splashPopupClicked:
@@ -42,6 +45,9 @@ enum AnalyticsEvent {
             
         case .clickAddressOk:
             return "click_address_ok"
+            
+        case .clickSelectCategory:
+            return "click_select_category"
         }
     }
     
@@ -73,6 +79,9 @@ enum AnalyticsEvent {
             
         case .clickAddressOk(let address):
             return ["address": address]
+            
+        case .clickSelectCategory(let categoryIds):
+            return ["category_id": categoryIds]
         }
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsScreen.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsScreen.swift
@@ -13,4 +13,6 @@ enum AnalyticsScreen: String {
     /// 제보 주소 화면
     case writeAddress = "write_address"
     case writeAddressPopup = "write_address_popop"
+    
+    case categorySelection = "category_selection"
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/PlatformStoreCategory.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/PlatformStoreCategory.swift
@@ -1,8 +1,11 @@
+import Networking
+
 struct PlatformStoreCategory: Categorizable {
     let id: String
     let category: String
     let description: String
     let imageUrl: String
+    let disableImageUrl: String
     let isNew: Bool
     let name: String
     
@@ -11,7 +14,24 @@ struct PlatformStoreCategory: Categorizable {
         self.category = response.category
         self.description = response.description
         self.imageUrl = response.imageUrl
+        self.disableImageUrl = ""
         self.isNew = response.isNew
         self.name = response.name
+    }
+    
+    init(response: Networking.PlatformStoreCategoryResponse) {
+        self.id = response.categoryId
+        self.category = response.category
+        self.description = response.description
+        self.imageUrl = response.imageUrl
+        self.disableImageUrl = response.disableImageUrl
+        self.isNew = response.isNew
+        self.name = response.name
+    }
+}
+
+extension PlatformStoreCategory: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }

--- a/Modules/DesignSystem/Sources/Button.swift
+++ b/Modules/DesignSystem/Sources/Button.swift
@@ -1,0 +1,97 @@
+import UIKit
+
+public class Button {
+    public class Normal: UIButton {
+        public enum Size {
+            case h52
+            case h34
+            
+            var height: CGFloat {
+                switch self {
+                case .h34:
+                    return 34
+                    
+                case .h52:
+                    return 52
+                }
+            }
+            
+            var iconSize: CGSize {
+                switch self {
+                case .h34:
+                    return CGSize(width: 16, height: 16)
+                    
+                case .h52:
+                    return CGSize(width: 24, height: 24)
+                }
+            }
+        }
+        
+        public override var isEnabled: Bool {
+            didSet {
+                UIView.transition(with: self, duration: 0.1) {
+                    self.backgroundColor = self.isEnabled ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
+                }
+            }
+        }
+        
+        private let size: Size
+        private var text: String?
+        private var leftIcon: UIImage?
+        
+        public init(size: Size, text: String? = nil, leftIcon: UIImage? = nil) {
+            self.size = size
+            self.text = text
+            self.leftIcon = leftIcon
+            
+            super.init(frame: .zero)
+            setup()
+            bindConstraints()
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+        private func setup() {
+            setTitle(text, for: .normal)
+            
+            setupIcon()
+            setupTitleLabel()
+            backgroundColor = DesignSystemAsset.Colors.mainPink.color
+            layer.cornerRadius = 12
+            layer.masksToBounds = true
+        }
+        
+        private func setupIcon() {
+            guard let leftIcon = leftIcon else { return }
+            setImage(leftIcon.withRenderingMode(.alwaysTemplate), for: .normal)
+            imageView?.translatesAutoresizingMaskIntoConstraints = false
+            imageView?.widthAnchor.constraint(equalToConstant: size.iconSize.width).isActive = true
+            imageView?.heightAnchor.constraint(equalToConstant: size.iconSize.height).isActive = true
+            
+            if let titleLabel = titleLabel {
+                imageView?.rightAnchor.constraint(equalTo: titleLabel.leftAnchor, constant: -4).isActive = true
+                imageView?.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor).isActive = true
+            }
+            tintColor = DesignSystemAsset.Colors.systemWhite.color
+        }
+        
+        private func setupTitleLabel() {
+            switch size {
+            case .h34:
+                titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
+                
+            case .h52:
+                titleLabel?.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 14)
+            }
+            
+            setTitleColor(DesignSystemAsset.Colors.systemWhite.color, for: .normal)
+        }
+        
+        private func bindConstraints() {
+            translatesAutoresizingMaskIntoConstraints = false
+            heightAnchor.constraint(equalToConstant: size.height).isActive = true
+        }
+    }
+}

--- a/Modules/Network/Sources/APIBase/Manager/RequestProvider.swift
+++ b/Modules/Network/Sources/APIBase/Manager/RequestProvider.swift
@@ -26,8 +26,9 @@ final class RequestProvider {
         var urlComponents = URLComponents(string: config.endPoint)
         urlComponents?.path = requestType.path
         
-        if requestType.method == .get {
-            urlComponents?.queryItems = requestType.queryItems
+        if requestType.method == .get,
+           let queryItems = requestType.queryItems {
+            urlComponents?.queryItems = queryItems
         }
         
         guard let url = urlComponents?.url else {

--- a/Modules/Network/Sources/APIBase/Model/RequestType.swift
+++ b/Modules/Network/Sources/APIBase/Model/RequestType.swift
@@ -8,11 +8,11 @@ public protocol RequestType {
 }
 
 extension RequestType {
-    var queryItems: [URLQueryItem] {
+    var queryItems: [URLQueryItem]? {
         if let param = param {
             return param.map { URLQueryItem(name: $0.key, value: String(describing: $0.value)) }
         } else {
-            return []
+            return nil
         }
     }
     

--- a/Modules/Network/Sources/APIs/CategoryService.swift
+++ b/Modules/Network/Sources/APIs/CategoryService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public protocol CategoryServiceProtocol {
+    func fetchCategoires() async -> Result<[PlatformStoreCategoryResponse], Error>
+}
+
+public struct CategoryService: CategoryServiceProtocol {
+    public init() { }
+    
+    public func fetchCategoires() async -> Result<[PlatformStoreCategoryResponse], Error> {
+        let request = FetchCategoryRequest()
+        
+        return await NetworkManager.shared.request(requestType: request)
+    }
+}

--- a/Modules/Network/Sources/APIs/Request/FetchCategoryRequest.swift
+++ b/Modules/Network/Sources/APIs/Request/FetchCategoryRequest.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct FetchCategoryRequest: RequestType {
+    var param: [String : Any]? {
+        return nil
+    }
+    
+    var method: RequestMethod {
+        return .get
+    }
+    
+    var path: String {
+        return "/api/v4/stores/categories"
+    }
+}

--- a/Modules/Network/Sources/APIs/Request/FetchCategoryRequest.swift
+++ b/Modules/Network/Sources/APIs/Request/FetchCategoryRequest.swift
@@ -10,6 +10,6 @@ struct FetchCategoryRequest: RequestType {
     }
     
     var path: String {
-        return "/api/v4/stores/categories"
+        return "/api/v4/store/categories"
     }
 }

--- a/Modules/Network/Sources/APIs/Response/PlatformStoreCategoryResponse.swift
+++ b/Modules/Network/Sources/APIs/Response/PlatformStoreCategoryResponse.swift
@@ -1,0 +1,9 @@
+public struct PlatformStoreCategoryResponse: Decodable {
+    public let category: String
+    public let categoryId: String
+    public let name: String
+    public let imageUrl: String
+    public let description: String
+    public let classificationType: String
+    public let isNew: Bool
+}

--- a/Modules/Network/Sources/APIs/Response/PlatformStoreCategoryResponse.swift
+++ b/Modules/Network/Sources/APIs/Response/PlatformStoreCategoryResponse.swift
@@ -3,6 +3,7 @@ public struct PlatformStoreCategoryResponse: Decodable {
     public let categoryId: String
     public let name: String
     public let imageUrl: String
+    public let disableImageUrl: String
     public let description: String
     public let classificationType: String
     public let isNew: Bool


### PR DESCRIPTION
### 모듈별 변경사항
- 앱 프로젝트
    - 제보하기 상세화면에서 진입할 수 있는 카테고리 선택 화면 구현했습니다.
    - 제보하기 상세화면 로그 구현
- 네트워크 모듈
    - 카테고리 서비스 구현 (카테고리 조회 API)
- 디자인 시스템
    - Button.Normal 컴포넌트 구현 (카테고리 선택 화면 하단에서 사용합니다.)

### 테스트
- 시뮬, 디바이스 모두 가능합니다.

<img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/assets/7058293/1efc2d97-b931-48da-a3b7-3014fba0ff0a" width=360>


### 테스트 케이스
- 딤처리 되면사 하단에서 뷰가 올라오는가?
- 콜렉션 뷰가 깨지지 않고 정상적으로 노출되는가? 카테고리들이 제대로 노출되는가?
- 1개 이상의 카테고리를 선택하면 하단 버튼이 활성화 되는가?
- 0개 카테고리가 선택되면 하단 버튼이 비활성화 되는가?
- 활성화 된 버튼을 터치하면 화면이 꺼지는가?
- 배경 터치하면 화면이 꺼지는가?

https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/assets/7058293/4b046c67-5bd6-4fec-a004-2a9201b36911

### ⚠️주의사항
- 아직 제보 상세화면이 완벽하게 구현되지 않아 닫기 버튼에 이벤트 바인딩 시켜서 확인했습니다.