### PR TITLE
가게 제보 상세화면

### DIFF
--- a/App/Derived/Sources/TuistStrings+ThreeDollarInMyPocket.swift
+++ b/App/Derived/Sources/TuistStrings+ThreeDollarInMyPocket.swift
@@ -632,6 +632,8 @@ public enum ThreeDollarInMyPocketStrings {
   public static let writeDetailHeaderPaymentType = ThreeDollarInMyPocketStrings.tr("Localization", "write_detail_header_payment_type")
   /// 가게형태
   public static let writeDetailHeaderStoreType = ThreeDollarInMyPocketStrings.tr("Localization", "write_detail_header_store_type")
+  /// 가게 이름
+  public static let writeDetailNamePlaceholer = ThreeDollarInMyPocketStrings.tr("Localization", "write_detail_name_placeholer")
   /// *다중선택 가능
   public static let writeDetailStoreCanSelectMulti = ThreeDollarInMyPocketStrings.tr("Localization", "write_detail_store_can_select_multi")
   /// (선택)

--- a/App/Targets/three-dollar-in-my-pocket/Resources/en.lproj/Localization.strings
+++ b/App/Targets/three-dollar-in-my-pocket/Resources/en.lproj/Localization.strings
@@ -300,6 +300,7 @@
 "write_detail_header_location" = "가게 위치";
 "write_detail_edit_location" = "수정";
 "write_detail_header_name" = "가게 이름";
+"write_detail_name_placeholer" = "가게 이름";
 "write_detail_header_store_type" = "가게형태";
 "write_detail_header_payment_type" = "결제방식";
 "write_detail_header_day" = "출몰시기";

--- a/App/Targets/three-dollar-in-my-pocket/Resources/ko.lproj/Localization.strings
+++ b/App/Targets/three-dollar-in-my-pocket/Resources/ko.lproj/Localization.strings
@@ -300,6 +300,7 @@
 "write_detail_header_location" = "가게 위치";
 "write_detail_edit_location" = "수정";
 "write_detail_header_name" = "가게 이름";
+"write_detail_name_placeholer" = "가게 이름";
 "write_detail_header_store_type" = "가게형태";
 "write_detail_header_payment_type" = "결제방식";
 "write_detail_header_day" = "출몰시기";

--- a/App/Targets/three-dollar-in-my-pocket/Sources/AppDelegate.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/AppDelegate.swift
@@ -96,6 +96,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func initializationNetworkModule() {
         Networking.NetworkManager.shared.configuration.endPoint = Bundle.baseURL
         Networking.NetworkManager.shared.configuration.userAgent = HTTPUtils.userAgent
+        Networking.NetworkManager.shared.configuration.authToken = UserDefaultsUtil().authToken
     }
     
     func application(

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseCollectionViewCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseCollectionViewCell.swift
@@ -1,9 +1,11 @@
 import UIKit
+import Combine
 
 import RxSwift
 
 class BaseCollectionViewCell: UICollectionViewCell {
     var disposeBag = DisposeBag()
+    var cancellables = Set<AnyCancellable>()
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseCollectionViewCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseCollectionViewCell.swift
@@ -22,6 +22,7 @@ class BaseCollectionViewCell: UICollectionViewCell {
         super.prepareForReuse()
         
         self.disposeBag = DisposeBag()
+        cancellables = Set<AnyCancellable>()
     }
     
     /// adSubviews와 화면의 기본 속성을 설정합니다.

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/base/BaseView.swift
@@ -1,10 +1,12 @@
 import UIKit
+import Combine
 
 import RxCocoa
 import RxSwift
 
 class BaseView: UIView {
     var disposeBag = DisposeBag()
+    var cancellables = Set<AnyCancellable>()
     
     private lazy var dimView = UIView(frame: self.frame).then {
         $0.backgroundColor = .clear

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/splash/SplashVC.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/splash/SplashVC.swift
@@ -13,7 +13,8 @@ class SplashVC: BaseVC {
     feedbackService: FeedbackService(),
     categoryService: CategoryService(),
     deviceService: DeviceService(),
-    advertisementService: AdvertisementService()
+    advertisementService: AdvertisementService(),
+    metadataManager: MetadataManager.shared
   )
   
   

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/splash/SplashViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/splash/SplashViewModel.swift
@@ -27,6 +27,7 @@ final class SplashViewModel: BaseViewModel {
     private let categoryService: CategoryServiceProtocol
     private let deviceService: DeviceServiceProtocol
     private let advertisementService: AdvertisementServiceProtocol
+    private let metadataManager: MetadataManager
     
     init(
         userDefaults: UserDefaultsUtil,
@@ -37,7 +38,8 @@ final class SplashViewModel: BaseViewModel {
         feedbackService: FeedbackServiceProtocol,
         categoryService: CategoryServiceProtocol,
         deviceService: DeviceServiceProtocol,
-        advertisementService: AdvertisementServiceProtocol
+        advertisementService: AdvertisementServiceProtocol,
+        metadataManager: MetadataManager = .shared
     ) {
         self.userDefaults = userDefaults
         self.userService = userService
@@ -48,6 +50,7 @@ final class SplashViewModel: BaseViewModel {
         self.categoryService = categoryService
         self.deviceService = deviceService
         self.advertisementService = advertisementService
+        self.metadataManager = metadataManager
         
         super.init()
         
@@ -58,6 +61,7 @@ final class SplashViewModel: BaseViewModel {
                 self?.fetchMedals()
                 self?.fetchStreetFoodCategories()
                 self?.fetchFoodTurckCategories()
+                self?.fetchMetadata()
             })
             .disposed(by: self.disposeBag)
     }
@@ -191,5 +195,9 @@ final class SplashViewModel: BaseViewModel {
                 self?.metaContext.advertisementMarker = advertisement
             })
             .disposed(by: self.disposeBag)
+    }
+    
+    private func fetchMetadata() {
+        self.metadataManager.fetchCategories()
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressCoordinator.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressCoordinator.swift
@@ -1,12 +1,12 @@
 protocol WriteAddressCoordinator: AnyObject, BaseCoordinator {
-    func goToWriteDetail(address: String, location: (Double, Double))
+    func goToWriteDetail(address: String, location: Location)
     
     func presentConfirmPopup(address: String)
 }
 
 extension WriteAddressCoordinator where Self: BaseViewController {
-    func goToWriteDetail(address: String, location: (Double, Double)) {
-        let viewController = WriteDetailViewController.instance(address: address, location: location)
+    func goToWriteDetail(address: String, location: Location) {
+        let viewController = WriteDetailViewController.instance(location: location, address: address)
         
         viewController.deleagte = self as? WriteDetailDelegate
         

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-address/WriteAddressViewController.swift
@@ -127,7 +127,7 @@ final class WriteAddressViewController: BaseViewController, WriteAddressCoordina
                 case .pushAddressDetail(let address, let location):
                     owner.coordinator?.goToWriteDetail(
                         address: address,
-                        location: (location.latitude, location.longitude)
+                        location: location
                     )
                     
                 case .presentConfirmPopup(let address):

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailCoordinator.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailCoordinator.swift
@@ -16,6 +16,9 @@ extension WriteDetailCoordinator where Self: BaseViewController {
     }
     
     func presentCategorySelection() {
+        let viewController = CategorySelectionViewController.instance()
+        viewController.delegate = self as? CategorySelectionDelegate
         
+        presenter.present(viewController, animated: true)
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailCoordinator.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailCoordinator.swift
@@ -1,0 +1,21 @@
+protocol WriteDetailCoordinator: AnyObject, BaseCoordinator {
+    func pop()
+    
+    func presentFullMap()
+    
+    func presentCategorySelection()
+}
+
+extension WriteDetailCoordinator where Self: BaseViewController {
+    func pop() {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    func presentFullMap() {
+        
+    }
+    
+    func presentCategorySelection() {
+        
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailCoordinator.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailCoordinator.swift
@@ -3,7 +3,7 @@ protocol WriteDetailCoordinator: AnyObject, BaseCoordinator {
     
     func presentFullMap()
     
-    func presentCategorySelection()
+    func presentCategorySelection(selectedCategories: [PlatformStoreCategory])
 }
 
 extension WriteDetailCoordinator where Self: BaseViewController {
@@ -15,8 +15,8 @@ extension WriteDetailCoordinator where Self: BaseViewController {
         
     }
     
-    func presentCategorySelection() {
-        let viewController = CategorySelectionViewController.instance()
+    func presentCategorySelection(selectedCategories: [PlatformStoreCategory]) {
+        let viewController = CategorySelectionViewController.instance(selectedCategories: selectedCategories)
         viewController.delegate = self as? CategorySelectionDelegate
         
         presenter.present(viewController, animated: true)

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -35,8 +35,9 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                 
                 return cell
                 
-            case .address:
+            case .address(let address):
                 let cell: WriteDetailAddressCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                cell.bind(address: address)
                 cell.editAddressButton
                     .controlPublisher(for: .touchUpInside)
                     .mapVoid

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -86,8 +86,9 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                 
                 return cell
                 
-            case .menuGroup:
+            case .menuGroup(let category):
                 let cell: WriteDetailMenuGroupCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                cell.bind(category: category)
                 
                 return cell
             }
@@ -183,7 +184,7 @@ enum WriteDetailSectionItem: Hashable {
     case paymentMethod
     case appearanceDay
     case categoryCollection([PlatformStoreCategory?])
-    case menuGroup
+    case menuGroup(PlatformStoreCategory)
     
     var size: CGSize {
         switch self {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -205,8 +205,8 @@ enum WriteDetailSectionItem: Hashable {
         case .appearanceDay:
             return WriteDetailDayCell.Layout.size
             
-        case .categoryCollection:
-            return WriteDetailCategoryCollectionCell.Layout.size(count: 0)
+        case .categoryCollection(let categories):
+            return WriteDetailCategoryCollectionCell.Layout.size(count: categories.count)
             
         case .menuGroup:
             return WriteDetailMenuGroupCell.Layout.size

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -46,8 +46,9 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                 
                 return cell
                 
-            case .name:
+            case .name(let name):
                 let cell: WriteDetailNameCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                cell.bind(name: name)
                 cell.nameField.publisher(for: \.text)
                     .map { $0 ?? "" }
                     .subscribe(viewModel.input.storeName)

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -89,6 +89,10 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
             case .menuGroup(let category):
                 let cell: WriteDetailMenuGroupCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
                 cell.bind(category: category)
+                cell.closeButton.controlPublisher(for: .touchUpInside)
+                    .map { _ in indexPath.row - 1 }
+                    .subscribe(viewModel.input.tapDeleteCategory)
+                    .store(in: &cell.cancellables)
                 
                 return cell
             }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -73,6 +73,9 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                 
             case .appearanceDay:
                 let cell: WriteDetailDayCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                cell.tapPublisher
+                    .subscribe(viewModel.input.tapDay)
+                    .store(in: &cell.cancellables)
                 
                 return cell
                 

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -9,7 +9,8 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
             WriteDetailTypeCell.self,
             WriteDetailPaymentCell.self,
             WriteDetailDayCell.self,
-            WriteDetailCategoryCollectionCell.self
+            WriteDetailCategoryCollectionCell.self,
+            WriteDetailMenuGroupCell.self
         ])
         collectionView.registerSectionHeader([
             WriteDetailHeaderView.self,
@@ -49,6 +50,11 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                 
             case .categoryCollection:
                 let cell: WriteDetailCategoryCollectionCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                
+                return cell
+                
+            case .menuGroup:
+                let cell: WriteDetailMenuGroupCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
                 
                 return cell
             }
@@ -136,6 +142,7 @@ enum WriteDetailSectionItem: Hashable {
     case payment
     case day
     case categoryCollection
+    case menuGroup
     
     var size: CGSize {
         switch self {
@@ -159,6 +166,9 @@ enum WriteDetailSectionItem: Hashable {
             
         case .categoryCollection:
             return WriteDetailCategoryCollectionCell.Layout.size(count: 0)
+            
+        case .menuGroup:
+            return WriteDetailMenuGroupCell.Layout.size
         }
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -79,8 +79,10 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                 
                 return cell
                 
-            case .categoryCollection:
+            case .categoryCollection(let categories):
                 let cell: WriteDetailCategoryCollectionCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                cell.bind(categories: categories)
+                cell.bindViewModel(viewModel)
                 
                 return cell
                 
@@ -116,6 +118,14 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                     withReuseIdentifier: "\(WriteDetailCategoryHeaderView.self)",
                     for: indexPath
                 ) as? WriteDetailCategoryHeaderView
+                
+                if let headerView = headerView {
+                    headerView.deleteButton
+                        .controlPublisher(for: .touchUpInside)
+                        .mapVoid
+                        .subscribe(viewModel.input.deleteAllCategories)
+                        .store(in: &headerView.cancellables)
+                }
                 
                 return headerView
             }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -65,6 +65,9 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                 
             case .paymentMethod:
                 let cell: WriteDetailPaymentCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                cell.tapPublisher
+                    .subscribe(viewModel.input.tapPaymentMethod)
+                    .store(in: &cell.cancellables)
                 
                 return cell
                 

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -24,8 +24,9 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
         ])
         super.init(collectionView: collectionView) { collectionView, indexPath, itemIdentifier in
             switch itemIdentifier {
-            case .map:
+            case .map(let location):
                 let cell: WriteDetailMapCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                cell.bind(location: location)
                 cell.zoomButton
                     .controlPublisher(for: .touchUpInside)
                     .mapVoid

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -86,9 +86,10 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                 
                 return cell
                 
-            case .menuGroup(let category):
+            case .menuGroup(let cellViewModel):
                 let cell: WriteDetailMenuGroupCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
-                cell.bind(category: category)
+                
+                cell.bind(viewModel: cellViewModel)
                 cell.closeButton.controlPublisher(for: .touchUpInside)
                     .map { _ in indexPath.row - 1 }
                     .subscribe(viewModel.input.tapDeleteCategory)
@@ -188,7 +189,7 @@ enum WriteDetailSectionItem: Hashable {
     case paymentMethod
     case appearanceDay
     case categoryCollection([PlatformStoreCategory?])
-    case menuGroup(PlatformStoreCategory)
+    case menuGroup(WriteDetailMenuGroupViewModel)
     
     var size: CGSize {
         switch self {
@@ -213,8 +214,8 @@ enum WriteDetailSectionItem: Hashable {
         case .categoryCollection(let categories):
             return WriteDetailCategoryCollectionCell.Layout.size(count: categories.count)
             
-        case .menuGroup:
-            return WriteDetailMenuGroupCell.Layout.size
+        case .menuGroup(let viewModel):
+            return WriteDetailMenuGroupCell.Layout.size(count: viewModel.output.menus.count)
         }
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailDataSource.swift
@@ -57,6 +57,9 @@ final class WriteDetailDataSource: UICollectionViewDiffableDataSource<WriteDetai
                 
             case .storeType:
                 let cell: WriteDetailTypeCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                cell.tapPublisher
+                    .subscribe(viewModel.input.tapStoreType)
+                    .store(in: &cell.cancellables)
                 
                 return cell
                 

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
@@ -524,6 +524,7 @@ final class WriteDetailView: BaseView {
     }
     
     func setSaveButtonEnable(isEnable: Bool) {
+        writeButton.isUserInteractionEnabled = isEnable
         writeButton.backgroundColor = isEnable ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
         writeButtonBg.backgroundColor = isEnable ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
     }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
@@ -3,10 +3,7 @@ import UIKit
 import DesignSystem
 
 final class WriteDetailView: BaseView {
-    
-//    let categoryCellWidth = ((UIScreen.main.bounds.width - 48) - (17 * 4)) / 5
-    
-    let bgTap = UITapGestureRecognizer().then {
+    private let bgTap = UITapGestureRecognizer().then {
         $0.cancelsTouchesInView = false
     }
     
@@ -32,197 +29,6 @@ final class WriteDetailView: BaseView {
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: generateLayout())
     
-//    let scrollView = UIScrollView().then {
-//        $0.showsVerticalScrollIndicator = false
-//        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 98, right: 0)
-//    }
-//
-//    let containerView = UIView()
-//
-//    let locationLabel = UILabel().then {
-//        $0.text = "write_location".localized
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 16)
-//        $0.textColor = .black
-//    }
-//
-//    let modifyLocationButton = UIButton().then {
-//        $0.setTitle("write_modify_location".localized, for: .normal)
-//        $0.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 14)
-//        $0.setTitleColor(UIColor(r: 255, g: 92, b: 67), for: .normal)
-//    }
-//
-//    let locationContainer = UIView().then {
-//        $0.backgroundColor = .white
-//    }
-//
-//    let locationFieldContainer = UIView().then {
-//        $0.backgroundColor = UIColor(r: 244, g: 244, b: 244)
-//        $0.layer.cornerRadius = 8
-//        $0.layer.borderWidth = 1
-//        $0.layer.borderColor = UIColor(r: 208, g: 208, b: 208).cgColor
-//    }
-//
-//    let locationValueLabel = UILabel().then {
-//        $0.textColor = .black
-//        $0.font = UIFont(name: "AppleSDGothicNeo-SemiBold", size: 16)
-//        $0.text = "주소주소"
-//    }
-//
-//    let storeInfoLabel = UILabel().then {
-//        $0.text = "write_store_info".localized
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 16)
-//        $0.textColor = .black
-//    }
-//
-//    let storeInfoContainer = UIView().then {
-//        $0.backgroundColor = .white
-//    }
-//
-//    let storeNameLabel = UILabel().then {
-//        $0.text = "write_store_info_name".localized
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 14)
-//        $0.textColor = .black
-//    }
-//
-//    let storeNameContainer = UIView().then {
-//        $0.layer.cornerRadius = 8
-//        $0.layer.borderWidth = 1
-//        $0.layer.borderColor = UIColor(r: 244, g: 244, b: 244).cgColor
-//    }
-//
-//    let storeNameField = UITextField().then {
-//        $0.textColor = .black
-//        $0.font = UIFont(name: "AppleSDGothicNeo-SemiBold", size: 16)
-//        $0.placeholder = "write_store_info_name_placeholder".localized
-//    }
-//
-//    let storeTypeLabel = UILabel().then {
-//        $0.text = "write_store_type".localized
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 16)
-//        $0.textColor = .black
-//    }
-//
-//    let storeTypeOptionLabel = UILabel().then {
-//        $0.text = "write_store_option".localized
-//        $0.textColor = UIColor(r: 183, g: 183, b: 183)
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 14)
-//    }
-//
-//    let storeTypeStackView = WriteDetailTypeStackView()
-//
-//    let paymentTypeLabel = UILabel().then {
-//        $0.text = "write_store_payment_type".localized
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 14)
-//        $0.textColor = .black
-//    }
-//
-//    let paymentTypeOptionLabel = UILabel().then {
-//        $0.text = "write_store_option".localized
-//        $0.textColor = UIColor(r: 183, g: 183, b: 183)
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 14)
-//    }
-//
-//    let paymentTypeMultiLabel = UILabel().then {
-//        $0.text = "write_store_payment_multi".localized
-//        $0.textColor = UIColor(r: 255, g: 161, b: 170)
-//        $0.font = UIFont(name: "AppleSDGothicNeo-SemiBold", size: 12)
-//    }
-//
-//    let paymentStackView = WriteDetailPaymentStackView()
-//
-//    let daysLabel = UILabel().then {
-//        $0.text = "write_store_days".localized
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 14)
-//        $0.textColor = .black
-//    }
-//
-//    let daysOptionLabel = UILabel().then {
-//        $0.text = "write_store_option".localized
-//        $0.textColor = UIColor(r: 183, g: 183, b: 183)
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 14)
-//    }
-//
-//    let dayStackView = DayStackInputView()
-//
-//    let categoryLabel = UILabel().then {
-//        $0.text = "write_store_category".localized
-//        $0.textColor = .black
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 16)
-//    }
-//
-//    let deleteAllButton = UIButton().then {
-//        $0.setTitle("write_store_delete_all_menu".localized, for: .normal)
-//        $0.setTitleColor(UIColor(r: 255, g: 92, b: 67), for: .normal)
-//        $0.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 14)
-//    }
-//
-//    let categoryContainer = UIView().then {
-//        $0.backgroundColor = .white
-//    }
-//
-//    lazy var categoryCollectionView = UICollectionView(
-//        frame: .zero,
-//        collectionViewLayout: UICollectionViewFlowLayout()
-//    ).then {
-//        let layout = LeftAlignedCollectionViewFlowLayout()
-//
-//        layout.minimumInteritemSpacing = 16
-//        layout.minimumLineSpacing = 20
-//        layout.estimatedItemSize = CGSize(
-//            width: self.categoryCellWidth,
-//            height: self.categoryCellWidth + 23
-//        )
-//        $0.collectionViewLayout = layout
-//        $0.backgroundColor = .clear
-//        $0.contentInset = UIEdgeInsets(top: 0, left: 24, bottom: 0, right: 24)
-//    }
-//
-//    let menuLabel = UILabel().then {
-//        $0.text = "write_store_menu".localized
-//        $0.textColor = .black
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 16)
-//        $0.isHidden = true
-//    }
-//
-//    let menuOptionLabel = UILabel().then {
-//        $0.text = "write_store_option".localized
-//        $0.textColor = UIColor(r: 183, g: 183, b: 183)
-//        $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 14)
-//        $0.isHidden = true
-//    }
-//
-//    let menuTableView = UITableView().then {
-//        $0.backgroundColor = .white
-//        $0.isScrollEnabled = false
-//        $0.rowHeight = UITableView.automaticDimension
-//        $0.separatorStyle = .none
-//        $0.sectionFooterHeight = 20
-//    }
-//
-//    let registerButtonBg = UIView().then {
-//        $0.layer.cornerRadius = 37
-//
-//        let shadowLayer = CAShapeLayer()
-//
-//        shadowLayer.path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: 232, height: 64), cornerRadius: 37).cgPath
-//        shadowLayer.fillColor = UIColor.init(r: 255, g: 255, b: 255, a: 0.6).cgColor
-//        shadowLayer.shadowColor = UIColor.black.cgColor
-//        shadowLayer.shadowPath = nil
-//        shadowLayer.shadowOffset = CGSize(width: 0, height: 1)
-//        shadowLayer.shadowOpacity = 0.3
-//        shadowLayer.shadowRadius = 10
-//        $0.layer.insertSublayer(shadowLayer, at: 0)
-//    }
-//
-//    let registerButton = UIButton().then {
-//        $0.setTitle("write_store_register_button".localized, for: .normal)
-//        $0.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 16)
-//        $0.isEnabled = false
-//        $0.setBackgroundColor(UIColor.init(r: 208, g: 208, b: 208), for: .disabled)
-//        $0.setBackgroundColor(UIColor.init(r: 255, g: 92, b: 67), for: .normal)
-//        $0.layer.masksToBounds = true
-//    }
-    
     let writeButton = UIButton().then {
         $0.backgroundColor = DesignSystemAsset.Colors.mainPink.color
         $0.setTitle("write_store_register_button".localized, for: .normal)
@@ -234,8 +40,8 @@ final class WriteDetailView: BaseView {
         $0.backgroundColor = DesignSystemAsset.Colors.mainPink.color
     }
     
-    
     override func setup() {
+        addGestureRecognizer(bgTap)
         backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         addSubViews([
             navigationView,
@@ -246,6 +52,8 @@ final class WriteDetailView: BaseView {
             writeButton,
             writeButtonBg
         ])
+        
+        bgTap.addTarget(self, action: #selector(onTapBackground))
     }
     
     override func bindConstraints() {
@@ -292,229 +100,31 @@ final class WriteDetailView: BaseView {
             $0.top.equalTo(safeAreaLayoutGuide.snp.bottom)
             $0.bottom.equalToSuperview()
         }
-        
-//        self.navigationView.snp.makeConstraints { (make) in
-//            make.left.right.top.equalToSuperview()
-//            make.bottom.equalTo(self.safeAreaLayoutGuide.snp.top).offset(60)
-//        }
-//
-//        self.backButton.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.centerY.equalTo(self.titleLabel)
-//        }
-//
-//        self.titleLabel.snp.makeConstraints { make in
-//            make.centerX.equalToSuperview()
-//            make.bottom.equalTo(self.navigationView).offset(-22)
-//        }
-//
-//        self.scrollView.snp.makeConstraints { (make) in
-//            make.left.right.bottom.equalToSuperview()
-//            make.top.equalTo(self.navigationView.snp.bottom)
-//        }
-//
-//        self.containerView.snp.makeConstraints { (make) in
-//            make.edges.equalTo(0)
-//            make.width.equalTo(frame.width)
-//            make.top.equalToSuperview()
-//            make.bottom.equalTo(self.menuTableView)
-//        }
-//
-//        self.locationLabel.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalToSuperview().offset(40)
-//        }
-//
-//        self.modifyLocationButton.snp.makeConstraints { make in
-//            make.right.equalToSuperview().offset(-24)
-//            make.centerY.equalTo(self.locationLabel)
-//        }
-//
-//        self.locationContainer.snp.makeConstraints { make in
-//            make.left.right.equalToSuperview()
-//            make.top.equalTo(self.locationLabel.snp.bottom).offset(16)
-//            make.bottom.equalTo(self.locationFieldContainer).offset(24)
-//        }
-//
-//        self.locationFieldContainer.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.right.equalToSuperview().offset(-24)
-//            make.top.equalTo(self.locationContainer).offset(24)
-//            make.bottom.equalTo(self.locationValueLabel).offset(13)
-//        }
-//
-//        self.locationValueLabel.snp.makeConstraints { make in
-//            make.left.equalTo(self.locationFieldContainer).offset(16)
-//            make.right.equalTo(self.locationFieldContainer).offset(-16)
-//            make.top.equalTo(self.locationFieldContainer).offset(16)
-//        }
-//
-//        self.storeInfoLabel.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalTo(self.locationContainer.snp.bottom).offset(33)
-//        }
-//
-//        self.storeInfoContainer.snp.makeConstraints { make in
-//            make.left.right.equalToSuperview()
-//            make.top.equalTo(self.storeInfoLabel.snp.bottom).offset(16)
-//            make.bottom.equalTo(self.dayStackView).offset(24)
-//        }
-//
-//        self.storeNameLabel.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalTo(self.storeInfoContainer).offset(30)
-//        }
-//
-//        self.storeNameContainer.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.right.equalToSuperview().offset(-24)
-//            make.top.equalTo(self.storeNameLabel.snp.bottom).offset(10)
-//            make.bottom.equalTo(self.storeNameField).offset(15)
-//        }
-//
-//        self.storeNameField.snp.makeConstraints { make in
-//            make.left.equalTo(self.storeNameContainer).offset(16)
-//            make.top.equalTo(self.storeNameContainer).offset(16)
-//            make.right.equalTo(self.storeNameContainer).offset(-16)
-//        }
-//
-//        self.storeTypeLabel.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalTo(self.storeNameContainer.snp.bottom).offset(40)
-//        }
-//
-//        self.storeTypeOptionLabel.snp.makeConstraints { make in
-//            make.left.equalTo(self.storeTypeLabel.snp.right).offset(6)
-//            make.centerY.equalTo(self.storeTypeLabel)
-//        }
-//
-//        self.storeTypeStackView.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalTo(self.storeTypeLabel.snp.bottom).offset(17)
-//        }
-//
-//        self.paymentTypeLabel.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalTo(self.storeTypeStackView.snp.bottom).offset(40)
-//        }
-//
-//        self.paymentTypeOptionLabel.snp.makeConstraints { make in
-//            make.left.equalTo(self.paymentTypeLabel.snp.right).offset(6)
-//            make.centerY.equalTo(self.paymentTypeLabel)
-//        }
-//
-//        self.paymentTypeMultiLabel.snp.makeConstraints { make in
-//            make.left.equalTo(self.paymentTypeOptionLabel.snp.right).offset(7)
-//            make.centerY.equalTo(self.paymentTypeLabel)
-//        }
-//
-//        self.paymentStackView.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalTo(self.paymentTypeLabel.snp.bottom).offset(16)
-//        }
-//
-//        self.registerButtonBg.snp.makeConstraints { (make) in
-//            make.centerX.equalToSuperview()
-//            make.width.equalTo(232)
-//            make.height.equalTo(64)
-//            make.bottom.equalToSuperview().offset(-32)
-//        }
-//
-//        self.registerButton.snp.makeConstraints { (make) in
-//            make.left.equalTo(registerButtonBg.snp.left).offset(8)
-//            make.right.equalTo(registerButtonBg.snp.right).offset(-8)
-//            make.top.equalTo(registerButtonBg.snp.top).offset(8)
-//            make.bottom.equalTo(registerButtonBg.snp.bottom).offset(-8)
-//        }
-//
-//        self.daysLabel.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalTo(self.paymentStackView.snp.bottom).offset(40)
-//        }
-//
-//        self.daysOptionLabel.snp.makeConstraints { make in
-//            make.left.equalTo(self.daysLabel.snp.right).offset(6)
-//            make.centerY.equalTo(self.daysLabel)
-//        }
-//
-//        self.dayStackView.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.right.equalToSuperview().offset(-24)
-//            make.top.equalTo(self.daysLabel.snp.bottom).offset(13)
-//        }
-//
-//        self.categoryLabel.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalTo(self.storeInfoContainer.snp.bottom).offset(40)
-//        }
-//
-//        self.deleteAllButton.snp.makeConstraints { make in
-//            make.right.equalToSuperview().offset(-24)
-//            make.centerY.equalTo(self.categoryLabel)
-//        }
-//
-//        self.categoryContainer.snp.makeConstraints { make in
-//            make.left.right.equalToSuperview()
-//            make.top.equalTo(self.categoryLabel.snp.bottom).offset(16)
-//            make.bottom.equalTo(self.categoryCollectionView).offset(24)
-//        }
-//
-//        self.categoryCollectionView.snp.makeConstraints { make in
-//            make.left.right.equalToSuperview()
-//            make.top.equalTo(self.categoryContainer).offset(24)
-//            make.height.equalTo(self.categoryCellWidth + 23)
-//        }
-//
-//        self.menuLabel.snp.makeConstraints { make in
-//            make.left.equalToSuperview().offset(24)
-//            make.top.equalTo(self.categoryContainer.snp.bottom).offset(20)
-//        }
-//
-//        self.menuOptionLabel.snp.makeConstraints { make in
-//            make.left.equalTo(self.menuLabel.snp.right).offset(4)
-//            make.centerY.equalTo(self.menuLabel)
-//        }
-//
-//        self.menuTableView.snp.makeConstraints { make in
-//            make.left.equalToSuperview()
-//            make.right.equalToSuperview()
-//            make.top.equalTo(self.menuLabel.snp.bottom).offset(12)
-//            make.height.equalTo(0)
-//        }
     }
-//
-//    override func layoutSubviews() {
-//        super.layoutSubviews()
-//        self.refreshMenuTableViewHeight()
-//        registerButton.layer.cornerRadius = registerButton.frame.height / 2
-//    }
-//
-//    override func layoutIfNeeded() {
-//        super.layoutIfNeeded()
-//        self.refreshMenuTableViewHeight()
-//    }
-//
-//    func refreshCategoryCollectionViewHeight() {
-//        self.categoryCollectionView.snp.updateConstraints { make in
-//            make.height.equalTo(self.categoryCollectionView.contentSize.height)
-//        }
-//    }
-//
-//    func refreshMenuTableViewHeight() {
-//        menuTableView.snp.updateConstraints { make in
-//            make.height.equalTo(self.menuTableView.contentSize.height)
-//        }
-//    }
-//
-//    func setStoreNameBorderColoe(isEmpty: Bool) {
-//        self.storeNameContainer.layer.borderColor = isEmpty ? UIColor(r: 244, g: 244, b: 244).cgColor : UIColor(r: 255, g: 161, b: 170).cgColor
-//    }
-//
-//    func setMenuHeader(menuSections: [MenuSection]) {
-//        self.menuLabel.isHidden = menuSections.isEmpty
-//        self.menuOptionLabel.isHidden = menuSections.isEmpty
-//    }
     
+    func setSaveButtonEnable(isEnable: Bool) {
+        writeButton.isUserInteractionEnabled = isEnable
+        writeButton.backgroundColor = isEnable ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
+        writeButtonBg.backgroundColor = isEnable ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
+    }
+    
+    func updateCollectionViewLayout(keyboardHeight: CGFloat) {
+        if keyboardHeight == 0 {
+            collectionView.snp.remakeConstraints {
+                $0.left.equalToSuperview()
+                $0.right.equalToSuperview()
+                $0.top.equalTo(navigationView.snp.bottom)
+                $0.bottom.equalTo(writeButton.snp.top)
+            }
+        } else {
+            collectionView.snp.remakeConstraints {
+                $0.left.equalToSuperview()
+                $0.right.equalToSuperview()
+                $0.top.equalTo(navigationView.snp.bottom)
+                $0.bottom.equalToSuperview().offset(-keyboardHeight)
+            }
+        }
+    }
     
     private func generateLayout() -> UICollectionViewFlowLayout {
         let layout = UICollectionViewFlowLayout()
@@ -525,9 +135,7 @@ final class WriteDetailView: BaseView {
         return layout
     }
     
-    func setSaveButtonEnable(isEnable: Bool) {
-        writeButton.isUserInteractionEnabled = isEnable
-        writeButton.backgroundColor = isEnable ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
-        writeButtonBg.backgroundColor = isEnable ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
+    @objc private func onTapBackground() {
+        endEditing(true)
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Combine
 
 import DesignSystem
 
@@ -54,6 +55,7 @@ final class WriteDetailView: BaseView {
         ])
         
         bgTap.addTarget(self, action: #selector(onTapBackground))
+        setBackgroundColorObserver()
     }
     
     override func bindConstraints() {
@@ -133,6 +135,16 @@ final class WriteDetailView: BaseView {
         layout.minimumLineSpacing = 0
         layout.minimumInteritemSpacing = 0
         return layout
+    }
+    
+    private func setBackgroundColorObserver() {
+        collectionView.publisher(for: \.contentOffset)
+            .withUnretained(self)
+            .sink { owner, contentOffset in
+                let isMinus = contentOffset.y <= 0
+                owner.collectionView.backgroundColor = isMinus ? DesignSystemAsset.Colors.systemWhite.color : DesignSystemAsset.Colors.gray0.color
+            }
+            .store(in: &cancellables)
     }
     
     @objc private func onTapBackground() {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
@@ -522,4 +522,9 @@ final class WriteDetailView: BaseView {
         layout.scrollDirection = .vertical
         return layout
     }
+    
+    func setSaveButtonEnable(isEnable: Bool) {
+        writeButton.backgroundColor = isEnable ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
+        writeButtonBg.backgroundColor = isEnable ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
+    }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailView.swift
@@ -520,6 +520,8 @@ final class WriteDetailView: BaseView {
         let layout = UICollectionViewFlowLayout()
         
         layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 0
+        layout.minimumInteritemSpacing = 0
         return layout
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
@@ -27,7 +27,6 @@ final class WriteDetailViewController: BaseViewController, WriteDetailCoordinato
     
     deinit {
         NotificationCenter.default.removeObserver(self)
-        //    self.writeDetailView.menuTableView.removeObserver(self, forKeyPath: "contentSize")
     }
     
     static func instance(location: Location, address: String) -> WriteDetailViewController {
@@ -35,33 +34,12 @@ final class WriteDetailViewController: BaseViewController, WriteDetailCoordinato
     }
     
     override func viewDidLoad() {
-        //    self.setupMenuTableView()
-        //    self.setupCategoryCollectionView()
-        //    self.setupKeyboardEvent()
-        
         super.viewDidLoad()
         view = writeDetailView
         coordinator = self
-        
+        observeKeyboardEvent()
         viewModel.input.viewDidLoad.send(())
-        
-        //    self.writeDetailView.scrollView.delegate = self
-        //    self.viewModel.fetchInitialData()
-        //    self.addObservers()
     }
-    
-    //  override func observeValue(
-    //    forKeyPath keyPath: String?,
-    //    of object: Any?,
-    //    change: [NSKeyValueChangeKey : Any]?,
-    //    context: UnsafeMutableRawPointer?
-    //  ) {
-    //    if let obj = object as? UITableView {
-    //      if obj == self.writeDetailView.menuTableView && keyPath == "contentSize" {
-    //        self.writeDetailView.refreshMenuTableViewHeight()
-    //      }
-    //    }
-    //  }
     
     override func bindEvent() {
         writeDetailView.backButton
@@ -79,11 +57,6 @@ final class WriteDetailViewController: BaseViewController, WriteDetailCoordinato
                 owner.coordinator?.dismiss()
             }
             .store(in: &cancellables)
-        
-        //    self.writeDetailView.bgTap.rx.event
-        //      .subscribe { [weak self] event in
-        //        self?.writeDetailView.endEditing(true)
-        //      }.disposed(by: disposeBag)
     }
     
     override func bindViewModelInput() {
@@ -162,6 +135,23 @@ final class WriteDetailViewController: BaseViewController, WriteDetailCoordinato
         
         dataSource.apply(snapshot, animatingDifferences: true)
     }
+    
+    private func observeKeyboardEvent() {
+        NotificationCenter.default.addObserver(self, selector: #selector(onShowKeyboard(notification:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(onHideKeyboard(notification:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func onShowKeyboard(notification: NSNotification) {
+        guard let userInfo = notification.userInfo,
+              let keyboardRect: CGRect = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+        let keyboardHeight: CGFloat = keyboardRect.height
+        
+        writeDetailView.updateCollectionViewLayout(keyboardHeight: keyboardHeight)
+    }
+    
+    @objc func onHideKeyboard(notification: NSNotification) {
+        writeDetailView.updateCollectionViewLayout(keyboardHeight: 0)
+    }
 }
 
 extension WriteDetailViewController: CategorySelectionDelegate {
@@ -169,64 +159,3 @@ extension WriteDetailViewController: CategorySelectionDelegate {
         viewModel.input.addCategories.send(categories)
     }
 }
-  
-//  private func addObservers() {
-//    self.writeDetailView.menuTableView.addObserver(
-//      self,
-//      forKeyPath: "contentSize",
-//      options: .new,
-//      context: nil
-//    )
-//  }
-//
-//  private func setupKeyboardEvent() {
-//    NotificationCenter.default.addObserver(self, selector: #selector(onShowKeyboard(notification:)), name: UIResponder.keyboardWillShowNotification, object: nil)
-//    NotificationCenter.default.addObserver(self, selector: #selector(onHideKeyboard(notification:)), name: UIResponder.keyboardWillHideNotification, object: nil)
-//  }
-//
-//  @objc func onShowKeyboard(notification: NSNotification) {
-//    let userInfo = notification.userInfo!
-//    var keyboardFrame:CGRect = (userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as! NSValue).cgRectValue
-//    keyboardFrame = self.view.convert(keyboardFrame, from: nil)
-//
-//    var contentInset:UIEdgeInsets = self.writeDetailView.scrollView.contentInset
-//    contentInset.bottom = keyboardFrame.size.height + 50
-//    self.writeDetailView.scrollView.contentInset = contentInset
-//  }
-//
-//  @objc func onHideKeyboard(notification: NSNotification) {
-//    let contentInset:UIEdgeInsets = UIEdgeInsets.zero
-//
-//    self.writeDetailView.scrollView.contentInset = contentInset
-//  }
-//}
-//
-//extension WriteDetailVC: UIScrollViewDelegate {
-//
-//  func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-//    self.writeDetailView.endEditing(true)
-//    self.writeDetailView.hideRegisterButton()
-//  }
-//
-//  func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-//    if !decelerate {
-//      self.writeDetailView.showRegisterButton()
-//    }
-//  }
-//
-//  func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-//    self.writeDetailView.showRegisterButton()
-//  }
-//}
-//
-//extension WriteDetailVC: AddCategoryDelegate {
-//
-//  func onDismiss() {
-//    self.writeDetailView.showDim(isShow: false)
-//  }
-//
-//  func onSuccess(selectedCategories: [StreetFoodStoreCategory]) {
-//    self.viewModel.input.addCategories.onNext(selectedCategories)
-//    self.writeDetailView.showDim(isShow: false)
-//  }
-//}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
@@ -163,6 +163,12 @@ final class WriteDetailViewController: BaseViewController, WriteDetailCoordinato
         dataSource.apply(snapshot, animatingDifferences: true)
     }
 }
+
+extension WriteDetailViewController: CategorySelectionDelegate {
+    func onSelectCategories(categories: [PlatformStoreCategory]) {
+        viewModel.input.addCategories.send(categories)
+    }
+}
   
 //  private func addObservers() {
 //    self.writeDetailView.menuTableView.addObserver(

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
@@ -63,7 +63,7 @@ final class WriteDetailViewController: BaseViewController {
             WriteDetailSection(type: .storeType, items: [.storeType]),
             WriteDetailSection(type: .payment, items: [.payment]),
             WriteDetailSection(type: .day, items: [.day]),
-            WriteDetailSection(type: .category, items: [.categoryCollection])
+            WriteDetailSection(type: .category, items: [.categoryCollection, .menuGroup]),
         ]
         
         sections.forEach {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
@@ -97,7 +97,10 @@ final class WriteDetailViewController: BaseViewController, WriteDetailCoordinato
     override func bindViewModelOutput() {
         viewModel.output.isSaveButtonEnable
             .receive(on: DispatchQueue.main)
-            .assign(to: \.isEnabled, on: writeDetailView.writeButton)
+            .withUnretained(self)
+            .sink(receiveValue: { owner, isEnable in
+                owner.writeDetailView.setSaveButtonEnable(isEnable: isEnable)
+            })
             .store(in: &cancellables)
         
         viewModel.output.showLoading

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewController.swift
@@ -117,8 +117,8 @@ final class WriteDetailViewController: BaseViewController, WriteDetailCoordinato
         case .presentFullMap:
             coordinator?.presentFullMap()
             
-        case .presentCategorySelection:
-            coordinator?.presentCategorySelection()
+        case .presentCategorySelection(let selectedCategories):
+            coordinator?.presentCategorySelection(selectedCategories: selectedCategories)
             
         case .dismiss:
             coordinator?.dismiss()

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
@@ -12,7 +12,7 @@ final class WriteDetailViewModel {
         let storeName = PassthroughSubject<String, Never>()
         let tapStoreType = PassthroughSubject<StreetFoodStoreType, Never>()
         let tapPaymentMethod = PassthroughSubject<PaymentType, Never>()
-        let tapDay = PassthroughSubject<WeekDay, Never>()
+        let tapDay = PassthroughSubject<DayOfTheWeek, Never>()
         let tapAddCategory = PassthroughSubject<Void, Never>()
         let tapDeleteCategory = PassthroughSubject<Int, Never>()
         let addCategories = PassthroughSubject<[PlatformStoreCategory], Never>()
@@ -36,7 +36,7 @@ final class WriteDetailViewModel {
         var name = ""
         var storeType: StreetFoodStoreType?
         var paymentMethods: [PaymentType] = []
-        var appearanceDays: [WeekDay] = []
+        var appearanceDays: [DayOfTheWeek] = []
         var categories: [PlatformStoreCategory] = []
         var menu: [[Menu]] = []
     }
@@ -112,11 +112,11 @@ final class WriteDetailViewModel {
         
         input.tapDay
             .withUnretained(self)
-            .sink { owner, weedDay in
-                if let targetIndex = owner.state.appearanceDays.firstIndex(of: weedDay) {
+            .sink { owner, dayOfTheWeek in
+                if let targetIndex = owner.state.appearanceDays.firstIndex(of: dayOfTheWeek) {
                     owner.state.appearanceDays.remove(at: targetIndex)
                 } else {
-                    owner.state.appearanceDays.append(weedDay)
+                    owner.state.appearanceDays.append(dayOfTheWeek)
                 }
             }
             .store(in: &cancellables)

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
@@ -201,14 +201,14 @@ final class WriteDetailViewModel {
     }
     
     private func updateSaveButtonEnable() {
-        let isEnable = state.name.isNotEmpty && state.menu.isNotEmpty
+        let isEnable = state.name.isNotEmpty && state.categories.isNotEmpty
         output.isSaveButtonEnable.send(isEnable)
     }
     
     private func updateSections() {
         let menuGroup = state.categories.map { WriteDetailSectionItem.menuGroup($0) }
         
-        var sections: [WriteDetailSection] = [
+        let sections: [WriteDetailSection] = [
             WriteDetailSection(type: .map, items: [.map(state.location)]),
             WriteDetailSection(type: .address, items: [.address(state.addess)]),
             WriteDetailSection(type: .name, items: [.name(state.name)]),

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
@@ -206,6 +206,8 @@ final class WriteDetailViewModel {
     }
     
     private func updateSections() {
+        let menuGroup = state.categories.map { WriteDetailSectionItem.menuGroup($0) }
+        
         var sections: [WriteDetailSection] = [
             WriteDetailSection(type: .map, items: [.map(state.location)]),
             WriteDetailSection(type: .address, items: [.address(state.addess)]),
@@ -213,7 +215,7 @@ final class WriteDetailViewModel {
             WriteDetailSection(type: .storeType, items: [.storeType]),
             WriteDetailSection(type: .paymentMethod, items: [.paymentMethod]),
             WriteDetailSection(type: .appearanceDay, items: [.appearanceDay]),
-            WriteDetailSection(type: .category, items: [.categoryCollection([nil] + state.categories)])
+            WriteDetailSection(type: .category, items: [ .categoryCollection([nil] + state.categories)] + menuGroup)
         ]
         
         // TODO: 메뉴 그룹 설정 필요

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
@@ -1,261 +1,241 @@
 import Foundation
+import Combine
 
-import RxSwift
-import RxCocoa
+import Networking
+import Common
 
-class WriteDetailViewModel: BaseViewModel {
-  
-  let input = Input()
-  let output = Output()
-  
-  let storeService: StoreServiceProtocol
-  let globalState: GlobalState
-  let address: String
-  let location: (Double, Double)
-  var appearenceDay: [WeekDay] = []
-  var categoryies: [StreetFoodStoreCategory?] = [nil]
-  var menusSections: [MenuSection] = []
-  var paymentType: [PaymentType] = []
-  
-  struct Input {
-    let storeName = PublishSubject<String>()
-    let tapDay = PublishSubject<WeekDay>()
-    let tapStoreType = BehaviorSubject<StreetFoodStoreType?>(value: nil)
-    let tapPaymentType = PublishSubject<PaymentType>()
-    let tapAddCategory = PublishSubject<Void>()
-    let tapCategoryDelete = PublishSubject<Int>()
-    let addCategories = PublishSubject<[StreetFoodStoreCategory]>()
-    let deleteAllCategories = PublishSubject<Void>()
-    let menuName = PublishSubject<(IndexPath, String)>()
-    let menuPrice = PublishSubject<(IndexPath, String)>()
-    let deleteCategory = PublishSubject<Int>()
-    let tapRegister = PublishSubject<Void>()
-  }
-  
-  struct Output {
-    let address = PublishRelay<String>()
-    let storeNameIsEmpty = PublishRelay<Bool>()
-    let selectType = PublishRelay<StreetFoodStoreType?>()
-    let selectPaymentType = PublishRelay<[PaymentType]>()
-    let selectDays = PublishRelay<[WeekDay]>()
-    let categories = PublishRelay<[StreetFoodStoreCategory?]>()
-    let showCategoryDialog = PublishRelay<[StreetFoodStoreCategory?]>()
-    let menus = PublishRelay<[MenuSection]>()
-    let fetchMenuTableViewHeight = PublishRelay<Void>()
-    let registerButtonIsEnable = PublishRelay<Bool>()
-    let dismissAndGoDetail = PublishRelay<Int>()
-    let showLoading = PublishRelay<Bool>()
-  }
-  
-  init(
-    address: String,
-    location: (Double, Double),
-    storeService: StoreServiceProtocol,
-    globalState: GlobalState
-  ) {
-    self.address = address
-    self.location = location
-    self.storeService = storeService
-    self.globalState = globalState
-    super.init()
-    
-    self.input.storeName
-      .map { $0.isEmpty }
-      .bind(to: self.output.storeNameIsEmpty)
-      .disposed(by: disposeBag)
-    
-    self.input.storeName
-      .map { !$0.isEmpty && !self.categoryies.compactMap { $0 }.isEmpty }
-      .bind(to: self.output.registerButtonIsEnable)
-      .disposed(by: disposeBag)
-    
-    self.input.tapDay
-      .bind(onNext: self.onTapDay(weekDay:))
-      .disposed(by: disposeBag)
-    
-    self.input.tapStoreType
-      .bind(to: self.output.selectType)
-      .disposed(by: disposeBag)
-    
-    self.input.tapPaymentType
-      .bind(onNext: self.onTapPayment(paymentType:))
-      .disposed(by: disposeBag)
-    
-    self.input.tapAddCategory
-      .map { self.categoryies }
-      .bind(to: self.output.showCategoryDialog)
-      .disposed(by: disposeBag)
-    
-    self.input.addCategories
-      .bind(onNext: self.onAddCategory(categories:))
-      .disposed(by: disposeBag)
-    
-    self.input.deleteAllCategories
-      .bind(onNext: self.onTapDeleteAllCategories)
-      .disposed(by: disposeBag)
-    
-    self.input.menuName
-      .bind(onNext: self.onEditMenuName)
-      .disposed(by: disposeBag)
-    
-    self.input.menuPrice
-      .bind(onNext: self.onEditMenuPrice)
-      .disposed(by: disposeBag)
-    
-    self.input.deleteCategory
-      .bind(onNext: self.deleteCategory(index:))
-      .disposed(by: disposeBag)
-    
-    self.input.tapRegister
-      .withLatestFrom(Observable.combineLatest(self.input.storeName, self.input.tapStoreType))
-      .map { Store(
-        appearanceDays: self.appearenceDay,
-        categories: self.categoryies.compactMap { $0 },
-        latitude: self.location.0,
-        longitude: self.location.1,
-        menuSections: self.menusSections,
-        paymentType: self.paymentType,
-        storeName: $0.0,
-        storeType: $0.1
-      ) }
-      .bind(onNext: self.saveStore(store:))
-      .disposed(by: disposeBag)
-    
-    self.output.categories
-      .withLatestFrom(self.input.storeName) { !$0.compactMap { $0 }.isEmpty && !$1.isEmpty }
-      .bind(to: self.output.registerButtonIsEnable)
-      .disposed(by: disposeBag)
-  }
-  
-  func fetchInitialData() {
-    Observable.just(self.address)
-      .bind(to: self.output.address)
-      .disposed(by: disposeBag)
-    
-    Observable.just(self.categoryies)
-      .bind(to: self.output.categories)
-      .disposed(by: disposeBag)
-  }
-  
-  private func deleteCategory(index: Int) {
-    if self.categoryies.count >= index + 1 {
-      self.categoryies.remove(at: index + 1)
-      Observable.just(self.categoryies)
-        .bind(to: self.output.categories)
-        .disposed(by: disposeBag)
+final class WriteDetailViewModel {
+    struct Input {
+        let viewDidLoad = PassthroughSubject<Void, Never>()
+        let tapFullMap = PassthroughSubject<Void, Never>()
+        let tapEditLocation = PassthroughSubject<Void, Never>()
+        let storeName = PassthroughSubject<String, Never>()
+        let tapStoreType = PassthroughSubject<StreetFoodStoreType, Never>()
+        let tapPaymentMethod = PassthroughSubject<PaymentType, Never>()
+        let tapDay = PassthroughSubject<WeekDay, Never>()
+        let tapAddCategory = PassthroughSubject<Void, Never>()
+        let tapDeleteCategory = PassthroughSubject<Int, Never>()
+        let addCategories = PassthroughSubject<[PlatformStoreCategory], Never>()
+        let deleteAllCategories = PassthroughSubject<Void, Never>()
+        let inputMenuName = PassthroughSubject<(IndexPath, String), Never>()
+        let inputMenuPrice = PassthroughSubject<(IndexPath, String), Never>()
+        let tapSave = PassthroughSubject<Void, Never>()
     }
     
-    self.menusSections.remove(at: index)
-    Observable.just(self.menusSections)
-      .bind(to: self.output.menus)
-      .disposed(by: disposeBag)
-  }
-  
-  private func onTapDay(weekDay: WeekDay) {
-    if self.appearenceDay.contains(weekDay) {
-      let removeIndex = self.appearenceDay.firstIndex(of: weekDay)!
-      
-      self.appearenceDay.remove(at: removeIndex)
-    } else {
-      self.appearenceDay.append(weekDay)
+    struct Output {
+        let isSaveButtonEnable = PassthroughSubject<Bool, Never>()
+        let showLoading = PassthroughSubject<Bool, Never>()
+        let route = PassthroughSubject<Route, Never>()
+        let error = PassthroughSubject<Error, Never>()
+        let sections = PassthroughSubject<[WriteDetailSection], Never>()
     }
     
-    Observable.just(self.appearenceDay)
-      .bind(to: self.output.selectDays)
-      .disposed(by: disposeBag)
-  }
-  
-  private func onTapPayment(paymentType: PaymentType) {
-    if self.paymentType.contains(paymentType) {
-      let removeIndex = self.paymentType.firstIndex(of: paymentType)!
-      
-      self.paymentType.remove(at: removeIndex)
-    } else {
-      self.paymentType.append(paymentType)
+    private struct State {
+        var location: Location
+        var addess: String
+        var name = ""
+        var storeType: StreetFoodStoreType?
+        var paymentMethods: [PaymentType] = []
+        var appearanceDays: [WeekDay] = []
+        var categories: [PlatformStoreCategory] = []
+        var menu: [[Menu]] = []
     }
     
-    Observable.just(self.paymentType)
-      .bind(to: self.output.selectPaymentType)
-      .disposed(by: disposeBag)
-  }
-  
-  private func onAddCategory(categories: [StreetFoodStoreCategory]) {
-    var newMenuSection: [MenuSection] = []
-    
-    for category in categories{
-      if self.categoryies.contains(category){
-        for menuSection in self.menusSections {
-          if menuSection.category == category {
-            newMenuSection.append(menuSection)
-            break
-          }
-        }
-      } else {
-        newMenuSection.append(MenuSection(category: category, items: [Menu(category: category)]))
-      }
+    enum Route {
+        case pop
+        case presentFullMap
+        case presentCategorySelection
+        case dismiss
     }
     
-    self.menusSections = newMenuSection
-    self.categoryies = [nil] + categories
-    self.output.categories.accept(self.categoryies)
-    self.output.menus.accept(self.menusSections)
-  }
-  
-  private func onTapDeleteAllCategories() {
-    self.categoryies = [nil]
-    self.menusSections = []
+    let input = Input()
+    let output = Output()
+    private var state: State
+    private let storeService: Networking.StoreServiceProtocol
+    private var cancellables = Set<AnyCancellable>()
     
-    self.output.categories.accept(categoryies)
-    self.output.menus.accept(menusSections)
-  }
-  
-  private func onEditMenuName(indexPath: IndexPath, name: String) {
-    if !name.isEmpty {
-      self.menusSections[indexPath.section].items[indexPath.row].name = name
-      if self.menusSections[indexPath.section].items.count == indexPath.row + 1 {
-        self.menusSections[indexPath.section].items.append(Menu(category: self.menusSections[indexPath.section].category))
+    init(
+        location: Location,
+        address: String,
+        storeService: Networking.StoreServiceProtocol = Networking.StoreService()
+    ) {
+        self.state = State(location: location, addess: address)
+        self.storeService = storeService
         
-        self.output.menus.accept(self.menusSections)
-      }
+        bind()
     }
-  }
-  
-  private func onEditMenuPrice(indexPath: IndexPath, price: String) {
-    if !price.isEmpty {
-      self.menusSections[indexPath.section].items[indexPath.row].price = price
-      if self.menusSections[indexPath.section].items.count == indexPath.row + 1 {
-        self.menusSections[indexPath.section].items.append(Menu(category: self.menusSections[indexPath.section].category))
+    
+    private func bind() {
+        input.viewDidLoad
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.updateSections()
+                owner.updateSaveButtonEnable()
+            }
+            .store(in: &cancellables)
         
-        self.output.menus.accept(self.menusSections)
-      }
+        input.tapFullMap
+            .map { .presentFullMap }
+            .subscribe(output.route)
+            .store(in: &cancellables)
+        
+        input.tapEditLocation
+            .map { .pop }
+            .subscribe(output.route)
+            .store(in: &cancellables)
+        
+        input.storeName
+            .withUnretained(self)
+            .sink { owner, name in
+                owner.state.name = name
+                owner.updateSaveButtonEnable()
+            }
+            .store(in: &cancellables)
+        
+        input.tapStoreType
+            .withUnretained(self)
+            .sink { owner, storeType in
+                owner.state.storeType = storeType
+            }
+            .store(in: &cancellables)
+        
+        input.tapPaymentMethod
+            .withUnretained(self)
+            .sink { owner, paymentMethod in
+                if let targetIndex = owner.state.paymentMethods.firstIndex(of: paymentMethod) {
+                    owner.state.paymentMethods.remove(at: targetIndex)
+                } else {
+                    owner.state.paymentMethods.append(paymentMethod)
+                }
+            }
+            .store(in: &cancellables)
+        
+        input.tapDay
+            .withUnretained(self)
+            .sink { owner, weedDay in
+                if let targetIndex = owner.state.appearanceDays.firstIndex(of: weedDay) {
+                    owner.state.appearanceDays.remove(at: targetIndex)
+                } else {
+                    owner.state.appearanceDays.append(weedDay)
+                }
+            }
+            .store(in: &cancellables)
+        
+        input.tapAddCategory
+            .map { .presentCategorySelection }
+            .subscribe(output.route)
+            .store(in: &cancellables)
+        
+        input.tapDeleteCategory
+            .withUnretained(self)
+            .sink { owner, index in
+                owner.state.categories.remove(at: index)
+                owner.updateSaveButtonEnable()
+                owner.updateSections()
+            }
+            .store(in: &cancellables)
+        
+        input.addCategories
+            .withUnretained(self)
+            .sink { owner, addedCategories in
+                owner.state.categories.append(contentsOf: addedCategories)
+                owner.updateSaveButtonEnable()
+                owner.updateSections()
+            }
+            .store(in: &cancellables)
+        
+        input.deleteAllCategories
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.state.categories.removeAll()
+                owner.updateSaveButtonEnable()
+                owner.updateSections()
+            }
+            .store(in: &cancellables)
+        
+        input.inputMenuName
+            .withUnretained(self)
+            .sink { owner, nameWithIndex in
+                let (indexPath, name) = nameWithIndex
+                guard owner.isExistMenu(indexPath: indexPath) else { return }
+                
+                owner.state.menu[indexPath.section][indexPath.row].name = name
+            }
+            .store(in: &cancellables)
+        
+        input.inputMenuPrice
+            .withUnretained(self)
+            .sink { owner, priceWithIndex in
+                let (indexPath, price) = priceWithIndex
+                guard owner.isExistMenu(indexPath: indexPath) else { return }
+                
+                owner.state.menu[indexPath.section][indexPath.row].price = price
+            }
+            .store(in: &cancellables)
+        
+        input.tapSave
+            .withUnretained(self)
+            .handleEvents(receiveOutput: { owner, _ in
+                owner.output.showLoading.send(true)
+            })
+            .map { owner, _ in
+                owner.createStoreCreateRequestInput()
+            }
+            .withUnretained(self)
+            .asyncMap { owner, input in
+                await owner.storeService.createStore(input: input)
+            }
+            .withUnretained(self)
+            .sink { owner, result in
+                owner.output.showLoading.send(false)
+                switch result {
+                case .success(let response):
+                    // TODO: GlobalEvnet로 응답 전달 필요. (홈 화면에 새로운 카드 추가, 가게 상세화면 이동)
+                    owner.output.route.send(.dismiss)
+
+                case .failure(let error):
+                    owner.output.error.send(error)
+                }
+            }
+            .store(in: &cancellables)
     }
-  }
-  
-  private func saveStore(store: Store) {
-    self.output.showLoading.accept(true)
-    self.storeService.saveStore(store: store)
-      .subscribe(
-        onNext: { [weak self] store in
-          guard let self = self else { return }
-          
-          self.globalState.addStore.onNext(store)
-          self.output.dismissAndGoDetail.accept(store.storeId)
-          self.output.showLoading.accept(false)
-        },
-        onError: { [weak self] error in
-          guard let self = self else { return }
-          if let httpError = error as? HTTPError{
-            self.httpErrorAlert.accept(httpError)
-          }
-          if let commonError = error as? CommonError {
-            let alertContent = AlertContent(title: nil, message: commonError.description)
-            
-            self.showSystemAlert.accept(alertContent)
-          }
-          
-          self.output.showLoading.accept(false)
-        }
-      )
-      .disposed(by: disposeBag)
-  }
+    
+    private func updateSaveButtonEnable() {
+        let isEnable = state.name.isNotEmpty && state.menu.isNotEmpty
+        output.isSaveButtonEnable.send(isEnable)
+    }
+    
+    private func updateSections() {
+        var sections: [WriteDetailSection] = [
+            WriteDetailSection(type: .map, items: [.map(state.location)]),
+            WriteDetailSection(type: .address, items: [.address(state.addess)]),
+            WriteDetailSection(type: .name, items: [.name(state.name)]),
+            WriteDetailSection(type: .storeType, items: [.storeType]),
+            WriteDetailSection(type: .paymentMethod, items: [.paymentMethod]),
+            WriteDetailSection(type: .appearanceDay, items: [.appearanceDay]),
+            WriteDetailSection(type: .category, items: [.categoryCollection([nil] + state.categories)])
+        ]
+        
+        // TODO: 메뉴 그룹 설정 필요
+        output.sections.send(sections)
+    }
+    
+    private func isExistMenu(indexPath: IndexPath) -> Bool {
+        guard let categoryMenus = state.menu[safe: indexPath.section],
+              let _ = categoryMenus[safe: indexPath.row] else { return false }
+        
+        return true
+    }
+    
+    private func createStoreCreateRequestInput() -> StoreCreateRequestInput {
+        return StoreCreateRequestInput(
+            latitude: state.location.latitude,
+            longitude: state.location.longitude,
+            storeName: state.name,
+            storeType: state.storeType?.rawValue,
+            appearanceDays: state.appearanceDays.map { $0.rawValue },
+            paymentMethods: state.paymentMethods.map { $0.rawValue },
+            menus: []
+        )
+    }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
@@ -265,7 +265,15 @@ final class WriteDetailViewModel {
     private func createStoreCreateRequestInput() -> StoreCreateRequestInput {
         var menuRequestInputs = [Networking.StoreMenuRequestInput]()
         for menuGroup in state.menu {
-            let requests = menuGroup.map { menu in
+            let emptyMenuCount = menuGroup.filter { !$0.isValid }.count
+            var filteredMenuGroup = [NewMenu]()
+            if emptyMenuCount == menuGroup.count {
+                filteredMenuGroup = [menuGroup[0]]
+            } else {
+                filteredMenuGroup = menuGroup.filter { $0.isValid }
+            }
+            
+            let requests = filteredMenuGroup.map { menu in
                 Networking.StoreMenuRequestInput(name: menu.name, price: menu.price, category: menu.category.category)
             }
             

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
@@ -263,6 +263,15 @@ final class WriteDetailViewModel {
     }
     
     private func createStoreCreateRequestInput() -> StoreCreateRequestInput {
+        var menuRequestInputs = [Networking.StoreMenuRequestInput]()
+        for menuGroup in state.menu {
+            let requests = menuGroup.map { menu in
+                Networking.StoreMenuRequestInput(name: menu.name, price: menu.price, category: [menu.category.category])
+            }
+            
+            menuRequestInputs.append(contentsOf: requests)
+        }
+        
         return StoreCreateRequestInput(
             latitude: state.location.latitude,
             longitude: state.location.longitude,
@@ -270,7 +279,7 @@ final class WriteDetailViewModel {
             storeType: state.storeType?.rawValue,
             appearanceDays: state.appearanceDays.map { $0.rawValue },
             paymentMethods: state.paymentMethods.map { $0.rawValue },
-            menus: []
+            menus: menuRequestInputs
         )
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/WriteDetailViewModel.swift
@@ -266,7 +266,7 @@ final class WriteDetailViewModel {
         var menuRequestInputs = [Networking.StoreMenuRequestInput]()
         for menuGroup in state.menu {
             let requests = menuGroup.map { menu in
-                Networking.StoreMenuRequestInput(name: menu.name, price: menu.price, category: [menu.category.category])
+                Networking.StoreMenuRequestInput(name: menu.name, price: menu.price, category: menu.category.category)
             }
             
             menuRequestInputs.append(contentsOf: requests)

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/category-selection/CategorySelectionCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/category-selection/CategorySelectionCell.swift
@@ -11,6 +11,7 @@ final class CategorySelectionCell: BaseCollectionViewCell {
     override var isSelected: Bool {
         didSet {
             categoryButton.layer.borderColor = isSelected ? DesignSystemAsset.Colors.mainPink.color.cgColor : DesignSystemAsset.Colors.gray30.color.cgColor
+            categoryButton.isSelected = isSelected
         }
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/category-selection/CategorySelectionViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/category-selection/CategorySelectionViewModel.swift
@@ -6,6 +6,7 @@ import Networking
 final class CategorySelectionViewModel {
     struct Input {
         let viewDidLoad = PassthroughSubject<Void, Never>()
+        let onLoadDataSource = PassthroughSubject<Void, Never>()
         let selectCategory = PassthroughSubject<Int, Never>()
         let deSelectCategory = PassthroughSubject<Int, Never>()
         let tapSelect = PassthroughSubject<Void, Never>()
@@ -13,6 +14,7 @@ final class CategorySelectionViewModel {
     
     struct Output {
         let categories = PassthroughSubject<[PlatformStoreCategory], Never>()
+        let selectCategories = PassthroughSubject<[PlatformStoreCategory], Never>()
         let isEnableSelectButton = PassthroughSubject<Bool, Never>()
         let error = PassthroughSubject<Error, Never>()
         let route = PassthroughSubject<Route, Never>()
@@ -22,22 +24,24 @@ final class CategorySelectionViewModel {
         case dismissWithCategories([PlatformStoreCategory])
     }
     
-    private struct State {
+    struct State {
         var categories: [PlatformStoreCategory] = []
         var selectedCategories: [PlatformStoreCategory] = []
     }
     
     let input = Input()
     let output = Output()
-    private var state = State()
+    private var state: State
     private var cancellables = Set<AnyCancellable>()
     private let analyticsManager: AnalyticsManagerProtocol
     private let metadataManager: MetadataManager
     
     init(
+        state: State,
         analyticsManager: AnalyticsManagerProtocol = AnalyticsManager.shared,
         metadataManager: MetadataManager = .shared
     ) {
+        self.state = state
         self.analyticsManager = analyticsManager
         self.metadataManager = metadataManager
         
@@ -55,7 +59,16 @@ final class CategorySelectionViewModel {
                 let categories = owner.metadataManager.categories
                 owner.state.categories = categories
                 owner.output.categories.send(categories)
+                owner.output.selectCategories.send(owner.state.selectedCategories)
             }
+            .store(in: &cancellables)
+        
+        input.onLoadDataSource
+            .withUnretained(self)
+            .map { owner, _ in
+                owner.state.selectedCategories
+            }
+            .subscribe(output.selectCategories)
             .store(in: &cancellables)
         
         input.selectCategory

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailAddressCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailAddressCell.swift
@@ -25,6 +25,7 @@ final class WriteDetailAddressCell: BaseCollectionViewCell {
     }
     
     override func setup() {
+        backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         contentView.addSubViews([
             containerView,
             addressLabel,

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailAddressCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailAddressCell.swift
@@ -2,7 +2,7 @@ import UIKit
 
 import DesignSystem
 
-final class WriteDetailLocationCell: BaseCollectionViewCell {
+final class WriteDetailAddressCell: BaseCollectionViewCell {
     enum Layout {
         static let size = CGSize(width: UIScreen.main.bounds.width, height: 60)
     }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryCollectionCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryCollectionCell.swift
@@ -5,7 +5,7 @@ import DesignSystem
 final class WriteDetailCategoryCollectionCell: BaseCollectionViewCell {
     enum Layout {
         static func size(count: Int) -> CGSize {
-            return CGSize(width: UIScreen.main.bounds.width, height: height(count: count) + 24)
+            return CGSize(width: UIScreen.main.bounds.width, height: height(count: count) + 24 + 12)
         }
         static func height(count: Int) -> CGFloat {
             let numberOfRow = numberOfRow(count: count)
@@ -48,7 +48,7 @@ final class WriteDetailCategoryCollectionCell: BaseCollectionViewCell {
             $0.left.equalToSuperview().offset(20)
             $0.right.equalToSuperview().offset(-20)
             $0.top.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().offset(-12)
         }
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryCollectionCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryCollectionCell.swift
@@ -7,7 +7,12 @@ final class WriteDetailCategoryCollectionCell: BaseCollectionViewCell {
         static func size(count: Int) -> CGSize {
             return CGSize(width: UIScreen.main.bounds.width, height: WriteDetailCollectionItemCell.Layout.size.height + 24)
         }
+        static let lineSpace: CGFloat = 16
+        static let itemSpace: CGFloat = 10
     }
+    
+    private var viewModel: WriteDetailViewModel?
+    private var categories: [PlatformStoreCategory?] = []
     
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: generateLayout()).then {
         $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
@@ -17,20 +22,10 @@ final class WriteDetailCategoryCollectionCell: BaseCollectionViewCell {
         $0.register([WriteDetailCollectionItemCell.self])
     }
     
-    private func generateLayout() -> UICollectionViewFlowLayout {
-        let layout = LeftAlignedCollectionViewFlowLayout()
-        layout.itemSize = WriteDetailCollectionItemCell.Layout.size
-        layout.minimumLineSpacing = 16
-        layout.minimumInteritemSpacing = 10
-        
-        return layout
-    }
-    
     override func setup() {
         backgroundColor = DesignSystemAsset.Colors.gray0.color
         contentView.addSubview(collectionView)
-        
-        
+           
         collectionView.dataSource = self
     }
     
@@ -42,15 +37,52 @@ final class WriteDetailCategoryCollectionCell: BaseCollectionViewCell {
             $0.bottom.equalToSuperview()
         }
     }
+    
+    func bind(categories: [PlatformStoreCategory?]) {
+        self.categories = categories
+        collectionView.reloadData()
+    }
+    
+    func bindViewModel(_ viewModel: WriteDetailViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    private func generateLayout() -> UICollectionViewFlowLayout {
+        let layout = LeftAlignedCollectionViewFlowLayout()
+        layout.itemSize = WriteDetailCollectionItemCell.Layout.size
+        layout.minimumLineSpacing = Layout.lineSpace
+        layout.minimumInteritemSpacing = Layout.itemSpace
+        
+        return layout
+    }
 }
 
 extension WriteDetailCategoryCollectionCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 8
+        return categories.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let category = categories[safe: indexPath.row] else { return UICollectionViewCell() }
         let cell: WriteDetailCollectionItemCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+        
+        cell.bind(category: category)
+        
+        if let viewModel = viewModel {
+            cell.closeButton
+                .controlPublisher(for: .touchUpInside)
+                .map { _ in indexPath.row - 1 }
+                .subscribe(viewModel.input.tapDeleteCategory)
+                .store(in: &cancellables)
+            
+            if indexPath.row == 0 {
+                cell.categoryButton
+                    .controlPublisher(for: .touchUpInside)
+                    .mapVoid
+                    .subscribe(viewModel.input.tapAddCategory)
+                    .store(in: &cell.cancellables)
+            }
+        }
         
         return cell
     }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryCollectionCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryCollectionCell.swift
@@ -5,10 +5,24 @@ import DesignSystem
 final class WriteDetailCategoryCollectionCell: BaseCollectionViewCell {
     enum Layout {
         static func size(count: Int) -> CGSize {
-            return CGSize(width: UIScreen.main.bounds.width, height: WriteDetailCollectionItemCell.Layout.size.height + 24)
+            return CGSize(width: UIScreen.main.bounds.width, height: height(count: count) + 24)
+        }
+        static func height(count: Int) -> CGFloat {
+            let numberOfRow = numberOfRow(count: count)
+            let space = lineSpace * (numberOfRow - 1)
+            
+            return WriteDetailCollectionItemCell.Layout.size.height * numberOfRow + space
+        }
+        static func numberOfRow(count: Int) -> CGFloat {
+            if count <= numberOfItemInRow {
+                return 1
+            } else {
+                return CGFloat(count / numberOfItemInRow) + 1
+            }
         }
         static let lineSpace: CGFloat = 16
         static let itemSpace: CGFloat = 10
+        static let numberOfItemInRow = 5
     }
     
     private var viewModel: WriteDetailViewModel?

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryHeaderView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryHeaderView.swift
@@ -47,7 +47,7 @@ final class WriteDetailCategoryHeaderView: UICollectionReusableView {
         if let buttonTitleLabel = deleteButton.titleLabel {
             deleteButton.imageView?.snp.makeConstraints {
                 $0.centerY.equalTo(buttonTitleLabel)
-                $0.right.equalTo(buttonTitleLabel.snp.left).offset(-4)
+                $0.right.equalTo(buttonTitleLabel.snp.left).offset(-4).priority(.high)
                 $0.width.height.equalTo(12)
             }
         }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryHeaderView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCategoryHeaderView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Combine
 
 import DesignSystem
 
@@ -13,13 +14,15 @@ final class WriteDetailCategoryHeaderView: UICollectionReusableView {
         $0.text = ThreeDollarInMyPocketStrings.writeDetailHeaderCategory
     }
     
-    private let deleteButton = UIButton().then {
+    let deleteButton = UIButton().then {
         $0.setTitle(ThreeDollarInMyPocketStrings.writeDetailHeaderDeleteAllMenu, for: .normal)
         $0.setTitleColor(DesignSystemAsset.Colors.mainRed.color, for: .normal)
         $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
         $0.setImage(DesignSystemAsset.Icons.delete.image.withRenderingMode(.alwaysTemplate), for: .normal)
         $0.tintColor = DesignSystemAsset.Colors.mainRed.color
     }
+    
+    var cancellables = Set<AnyCancellable>()
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCollectionItemCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCollectionItemCell.swift
@@ -5,7 +5,7 @@ import DesignSystem
 final class WriteDetailCollectionItemCell: BaseCollectionViewCell {
     enum Layout {
         static let width = (UIScreen.main.bounds.width - 40 - 24 - 40)/5
-        static let size = CGSize(width: width, height: width + 22)
+        static let size = CGSize(width: width, height: width - 14 + 22)
     }
     
     let categoryButton = UIButton().then {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCollectionItemCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCollectionItemCell.swift
@@ -9,7 +9,7 @@ final class WriteDetailCollectionItemCell: BaseCollectionViewCell {
     }
     
     let categoryButton = UIButton().then {
-        $0.layer.cornerRadius = Layout.width / 2
+        $0.layer.cornerRadius = (Layout.width - 14) / 2
         $0.layer.masksToBounds = true
         $0.layer.borderColor = DesignSystemAsset.Colors.mainPink.color.cgColor
         $0.contentEdgeInsets = .init(top: 8, left: 8, bottom: 8, right: 8)
@@ -49,7 +49,7 @@ final class WriteDetailCollectionItemCell: BaseCollectionViewCell {
         categoryButton.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.centerX.equalToSuperview()
-            $0.width.height.equalTo(Layout.width)
+            $0.width.height.equalTo(Layout.width - 14)
         }
         
         closeButton.snp.makeConstraints {
@@ -61,7 +61,7 @@ final class WriteDetailCollectionItemCell: BaseCollectionViewCell {
         titleLabel.snp.makeConstraints {
             $0.left.equalToSuperview()
             $0.right.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.top.equalTo(categoryButton.snp.bottom).offset(4)
         }
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCollectionItemCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailCollectionItemCell.swift
@@ -9,9 +9,10 @@ final class WriteDetailCollectionItemCell: BaseCollectionViewCell {
     }
     
     let categoryButton = UIButton().then {
-        $0.backgroundColor = .black
         $0.layer.cornerRadius = Layout.width / 2
         $0.layer.masksToBounds = true
+        $0.layer.borderColor = DesignSystemAsset.Colors.mainPink.color.cgColor
+        $0.contentEdgeInsets = .init(top: 8, left: 8, bottom: 8, right: 8)
     }
     
     let closeButton = UIButton().then {
@@ -19,13 +20,21 @@ final class WriteDetailCollectionItemCell: BaseCollectionViewCell {
         $0.layer.cornerRadius = 8
         $0.setImage(DesignSystemAsset.Icons.close.image.withRenderingMode(.alwaysTemplate), for: .normal)
         $0.tintColor = DesignSystemAsset.Colors.gray0.color
+        $0.contentEdgeInsets = .init(top: 3, left: 3, bottom: 3, right: 3)
     }
     
     let titleLabel = UILabel().then {
         $0.font = DesignSystemFontFamily.Pretendard.medium.font(size: 12)
         $0.textColor = DesignSystemAsset.Colors.gray80.color
-        $0.text = "추가하기"
         $0.textAlignment = .center
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        closeButton.isHidden = false
+        categoryButton.backgroundColor = .clear
+        categoryButton.layer.borderWidth = 0
     }
     
     override func setup() {
@@ -54,5 +63,23 @@ final class WriteDetailCollectionItemCell: BaseCollectionViewCell {
             $0.right.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
+    }
+    
+    func bind(category: PlatformStoreCategory?) {
+        if let category = category {
+            categoryButton.layer.borderWidth = 1
+            categoryButton.setImage(urlString: category.imageUrl, state: .normal)
+            titleLabel.text = category.name
+        } else {
+            setAddButton()
+        }
+    }
+    
+    private func setAddButton() {
+        closeButton.isHidden = true
+        categoryButton.backgroundColor = DesignSystemAsset.Colors.gray100.color
+        categoryButton.setImage(DesignSystemAsset.Icons.plus.image.withTintColor(DesignSystemAsset.Colors.mainPink.color), for: .normal)
+        categoryButton.layer.borderWidth = 0
+        titleLabel.text = "추가하기"
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailDayCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailDayCell.swift
@@ -15,6 +15,7 @@ final class WriteDetailDayCell: BaseCollectionViewCell {
     private let dayStackView = DayStackView()
     
     override func setup() {
+        backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         contentView.addSubview(dayStackView)
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailHeaderView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailHeaderView.swift
@@ -34,6 +34,7 @@ final class WriteDetailHeaderView: UICollectionReusableView {
     }
     
     private func setup() {
+        backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         stackView.addArrangedSubview(titleLabel)
         addSubview(stackView)
     }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMapCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMapCell.swift
@@ -37,6 +37,7 @@ final class WriteDetailMapCell: BaseCollectionViewCell {
     }
     
     override func setup() {
+        backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         contentView.addSubViews([
             mapView,
             zoomButton
@@ -67,7 +68,7 @@ final class WriteDetailMapCell: BaseCollectionViewCell {
         marker?.height = 40
         marker?.mapView = mapView
         
-        let cameraUpdate = NMFCameraUpdate(position: .init(targetLocation, zoom: 10))
+        let cameraUpdate = NMFCameraUpdate(position: .init(targetLocation, zoom: 15))
         mapView.moveCamera(cameraUpdate)
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMapCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMapCell.swift
@@ -4,15 +4,18 @@ import DesignSystem
 import NMapsMap
 
 final class WriteDetailMapCell: BaseCollectionViewCell {
+    var marker: NMFMarker?
+    
     enum Layout {
         static let size = CGSize(width: UIScreen.main.bounds.width, height: 166)
     }
     
     let mapView = NMFMapView().then {
         $0.positionMode = .direction
-        $0.zoomLevel = 10
+        $0.zoomLevel = 15
         $0.layer.cornerRadius = 20
         $0.layer.masksToBounds = true
+        $0.isUserInteractionEnabled = false
     }
     
     let zoomButton = UIButton().then {
@@ -26,6 +29,11 @@ final class WriteDetailMapCell: BaseCollectionViewCell {
         $0.layer.shadowOpacity = 0.1
         $0.contentEdgeInsets = .init(top: 8, left: 8, bottom: 8, right: 8)
         $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        marker?.mapView = nil
     }
     
     override func setup() {
@@ -48,5 +56,18 @@ final class WriteDetailMapCell: BaseCollectionViewCell {
             $0.bottom.equalTo(mapView).offset(-8)
             $0.right.equalTo(mapView).offset(-8)
         }
+    }
+    
+    func bind(location: Location) {
+        marker = NMFMarker()
+        let targetLocation = NMGLatLng(lat: location.latitude, lng: location.longitude)
+        marker?.position = targetLocation
+        marker?.iconImage = NMFOverlayImage(image: DesignSystemAsset.Icons.markerFocuesd.image)
+        marker?.width = 32
+        marker?.height = 40
+        marker?.mapView = mapView
+        
+        let cameraUpdate = NMFCameraUpdate(position: .init(targetLocation, zoom: 10))
+        mapView.moveCamera(cameraUpdate)
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupCell.swift
@@ -4,7 +4,8 @@ import DesignSystem
 
 final class WriteDetailMenuGroupCell: BaseCollectionViewCell {
     enum Layout {
-        static let size = CGSize(width: UIScreen.main.bounds.width, height: 160)
+        static let size = CGSize(width: UIScreen.main.bounds.width, height: 160 + topOffset)
+        static let topOffset: CGFloat = 12
     }
     
     private let containerView = UIView().then {
@@ -15,7 +16,10 @@ final class WriteDetailMenuGroupCell: BaseCollectionViewCell {
     
     private let categoryImageView = UIImageView()
     
-    private let categoryNameLabel = UILabel()
+    private let categoryNameLabel = UILabel().then {
+        $0.font = DesignSystemFontFamily.Pretendard.bold.font(size: 14)
+        $0.textColor = DesignSystemAsset.Colors.gray90.color
+    }
     
     private let closeButton = UIButton().then {
         $0.backgroundColor = DesignSystemAsset.Colors.mainRed.color
@@ -47,7 +51,7 @@ final class WriteDetailMenuGroupCell: BaseCollectionViewCell {
             $0.left.equalToSuperview().offset(20)
             $0.right.equalToSuperview().offset(-20)
             $0.top.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().offset(-Layout.topOffset)
         }
         
         categoryImageView.snp.makeConstraints {
@@ -73,6 +77,11 @@ final class WriteDetailMenuGroupCell: BaseCollectionViewCell {
             $0.top.equalTo(categoryImageView.snp.bottom).offset(16)
             $0.bottom.equalToSuperview()
         }
+    }
+    
+    func bind(category: PlatformStoreCategory) {
+        categoryImageView.setImage(urlString: category.imageUrl)
+        categoryNameLabel.text = category.name
     }
     
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupCell.swift
@@ -4,9 +4,23 @@ import DesignSystem
 
 final class WriteDetailMenuGroupCell: BaseCollectionViewCell {
     enum Layout {
-        static let size = CGSize(width: UIScreen.main.bounds.width, height: 160 + topOffset)
+        static func size(count: Int) -> CGSize {
+            let width = UIScreen.main.bounds.width
+            let itemGroupHeight = itemGroupHeight(count: count)
+            
+            return CGSize(width: width, height: itemGroupHeight + topOffset + 64)
+        }
         static let topOffset: CGFloat = 12
+        static func itemGroupHeight(count: Int) -> CGFloat {
+            let itemHeight = WriteDetailMenuItemCell.Layout.size.height * CGFloat(count)
+            let space = count - 1 > 0 ? space * CGFloat(count - 1) : 0
+            
+            return itemHeight + space + topOffset
+        }
+        static let space: CGFloat = 8
     }
+    
+    private var viewModel: WriteDetailMenuGroupViewModel?
     
     private let containerView = UIView().then {
         $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
@@ -77,11 +91,13 @@ final class WriteDetailMenuGroupCell: BaseCollectionViewCell {
         }
     }
     
-    func bind(category: PlatformStoreCategory) {
-        categoryImageView.setImage(urlString: category.imageUrl)
-        categoryNameLabel.text = category.name
+    func bind(viewModel: WriteDetailMenuGroupViewModel) {
+        self.viewModel = viewModel
+        
+        categoryImageView.setImage(urlString: viewModel.output.category.imageUrl)
+        categoryNameLabel.text = viewModel.output.category.name
+        menuCollectionView.reloadData()
     }
-    
     
     private func generateLayout() -> UICollectionViewLayout {
         let layout = UICollectionViewFlowLayout()
@@ -96,11 +112,12 @@ final class WriteDetailMenuGroupCell: BaseCollectionViewCell {
 
 extension WriteDetailMenuGroupCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 2
+        return viewModel?.output.menus.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell: WriteDetailMenuItemCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+        cell.bind(viewModel: viewModel, index: indexPath.row)
         
         return cell
     }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupCell.swift
@@ -1,0 +1,100 @@
+import UIKit
+
+import DesignSystem
+
+final class WriteDetailMenuGroupCell: BaseCollectionViewCell {
+    enum Layout {
+        static let size = CGSize(width: UIScreen.main.bounds.width, height: 160)
+    }
+    
+    private let containerView = UIView().then {
+        $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
+        $0.layer.cornerRadius = 16
+        $0.layer.masksToBounds = true
+    }
+    
+    private let categoryImageView = UIImageView()
+    
+    private let categoryNameLabel = UILabel()
+    
+    private let closeButton = UIButton().then {
+        $0.backgroundColor = DesignSystemAsset.Colors.mainRed.color
+        $0.layer.cornerRadius = 10
+        $0.layer.masksToBounds = true
+        $0.setImage(DesignSystemAsset.Icons.close.image.withRenderingMode(.alwaysTemplate), for: .normal)
+        $0.tintColor = DesignSystemAsset.Colors.gray0.color
+        $0.contentEdgeInsets = .init(top: 6.4, left: 6.4, bottom: 6.4, right: 6.4)
+    }
+    
+    lazy var menuCollectionView = UICollectionView(frame: .zero, collectionViewLayout: generateLayout()).then {
+        $0.register([WriteDetailMenuItemCell.self])
+        $0.dataSource = self
+    }
+    
+    override func setup() {
+        backgroundColor = DesignSystemAsset.Colors.gray0.color
+        containerView.addSubViews([
+            categoryImageView,
+            categoryNameLabel,
+            closeButton,
+            menuCollectionView
+        ])
+        contentView.addSubview(containerView)
+    }
+    
+    override func bindConstraints() {
+        containerView.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(20)
+            $0.right.equalToSuperview().offset(-20)
+            $0.top.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+        
+        categoryImageView.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(12)
+            $0.top.equalToSuperview().offset(12)
+            $0.width.height.equalTo(24)
+        }
+        
+        categoryNameLabel.snp.makeConstraints {
+            $0.centerY.equalTo(categoryImageView)
+            $0.left.equalTo(categoryImageView.snp.right).offset(4)
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.right.equalToSuperview().offset(-12)
+            $0.centerY.equalTo(categoryImageView)
+            $0.width.height.equalTo(20)
+        }
+        
+        menuCollectionView.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(12)
+            $0.right.equalToSuperview().offset(-12)
+            $0.top.equalTo(categoryImageView.snp.bottom).offset(16)
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+    
+    private func generateLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.itemSize = WriteDetailMenuItemCell.Layout.size
+        layout.minimumInteritemSpacing = 8
+        layout.minimumLineSpacing = 8
+        
+        return layout
+    }
+}
+
+extension WriteDetailMenuGroupCell: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 2
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell: WriteDetailMenuItemCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+        
+        return cell
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupCell.swift
@@ -21,13 +21,11 @@ final class WriteDetailMenuGroupCell: BaseCollectionViewCell {
         $0.textColor = DesignSystemAsset.Colors.gray90.color
     }
     
-    private let closeButton = UIButton().then {
+    let closeButton = UIButton().then {
         $0.backgroundColor = DesignSystemAsset.Colors.mainRed.color
         $0.layer.cornerRadius = 10
-        $0.layer.masksToBounds = true
-        $0.setImage(DesignSystemAsset.Icons.close.image.withRenderingMode(.alwaysTemplate), for: .normal)
-        $0.tintColor = DesignSystemAsset.Colors.gray0.color
-        $0.contentEdgeInsets = .init(top: 6.4, left: 6.4, bottom: 6.4, right: 6.4)
+        $0.setImage(DesignSystemAsset.Icons.close.image.withTintColor(DesignSystemAsset.Colors.gray0.color), for: .normal)
+        $0.contentEdgeInsets = .init(top: 4, left: 4, bottom: 4, right: 4)
     }
     
     lazy var menuCollectionView = UICollectionView(frame: .zero, collectionViewLayout: generateLayout()).then {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuGroupViewModel.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Combine
+
+final class WriteDetailMenuGroupViewModel: Hashable {
+    static func == (lhs: WriteDetailMenuGroupViewModel, rhs: WriteDetailMenuGroupViewModel) -> Bool {
+        return lhs.output.menus == rhs.output.menus
+    }
+    
+    struct Input {
+        let inputMenuName = PassthroughSubject<(Int, String), Never>()
+        let inputMenuPrice = PassthroughSubject<(Int, String), Never>()
+    }
+    
+    struct Output {
+        let inputMenuName = PassthroughSubject<(IndexPath, String), Never>()
+        let inputMenuPrice = PassthroughSubject<(IndexPath, String), Never>()
+        var category: PlatformStoreCategory
+        var menus: [NewMenu]
+    }
+    
+    struct State {
+        var menuIndex: Int
+        var category: PlatformStoreCategory
+        var menu: [NewMenu]
+    }
+    
+    let input = Input()
+    var output: Output
+    private var state: State
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(state: State) {
+        self.state = state
+        
+        output = Output(category: state.category, menus: state.menu)
+        bind()
+    }
+    
+    private func bind() {
+        input.inputMenuName
+            .withUnretained(self)
+            .handleEvents(receiveOutput: { owner, input in
+                let (index, name) = input
+                
+                owner.state.menu[index].name = name
+            })
+            .map { owner, input in
+                let (index, name) = input
+                let indexPath = IndexPath(row: index, section: owner.state.menuIndex)
+                
+                return (indexPath, name)
+            }
+            .subscribe(output.inputMenuName)
+            .store(in: &cancellables)
+        
+        input.inputMenuPrice
+            .withUnretained(self)
+            .handleEvents(receiveOutput: { owner, input in
+                let (index, price) = input
+                
+                owner.state.menu[index].price = price
+            })
+            .map { owner, input in
+                let (index, price) = input
+                let indexPath = IndexPath(row: index, section: owner.state.menuIndex)
+                
+                return (indexPath, price)
+            }
+            .subscribe(output.inputMenuPrice)
+            .store(in: &cancellables)
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(output.menus)
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuItemCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuItemCell.swift
@@ -14,6 +14,13 @@ final class WriteDetailMenuItemCell: BaseCollectionViewCell {
     
     let descriptionField = TextField(placeholder: "ex) 3개 2천원")
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        nameField.text = nil
+        descriptionField.text = nil
+    }
+    
     override func setup() {
         contentView.addSubViews([
             nameField,
@@ -57,6 +64,7 @@ extension WriteDetailMenuItemCell {
         }
         
         private func setup() {
+            delegate = self
             layer.cornerRadius = 12
             layer.borderWidth = 0
             layer.borderColor = DesignSystemAsset.Colors.mainPink.color.cgColor
@@ -94,5 +102,12 @@ extension WriteDetailMenuItemCell {
                 }
                 .store(in: &cancellables)
         }
+    }
+}
+
+extension WriteDetailMenuItemCell.TextField: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return false
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuItemCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuItemCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Combine
 
 import DesignSystem
 
@@ -39,19 +40,15 @@ final class WriteDetailMenuItemCell: BaseCollectionViewCell {
 
 extension WriteDetailMenuItemCell {
     final class TextField: UITextField {
+        private var cancellables = Set<AnyCancellable>()
+        
         init(placeholder: String? = nil) {
             super.init(frame: .zero)
             
             setup()
-            
+            bindEvent()
             if let placeholder = placeholder {
-                let attributedString = NSAttributedString(
-                    string: placeholder,
-                    attributes: [
-                        .font: DesignSystemFontFamily.Pretendard.regular.font(size: 14),
-                        .foregroundColor: DesignSystemAsset.Colors.gray40.color
-                    ])
-                attributedPlaceholder = attributedString
+                setPlaceholder(text: placeholder)
             }
         }
         
@@ -61,7 +58,7 @@ extension WriteDetailMenuItemCell {
         
         private func setup() {
             layer.cornerRadius = 12
-            layer.borderWidth = 1
+            layer.borderWidth = 0
             layer.borderColor = DesignSystemAsset.Colors.mainPink.color.cgColor
             leftView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 44))
             leftViewMode = .always
@@ -69,6 +66,33 @@ extension WriteDetailMenuItemCell {
             rightViewMode = .always
             font = DesignSystemFontFamily.Pretendard.regular.font(size: 14)
             backgroundColor = DesignSystemAsset.Colors.gray10.color
+            returnKeyType = .done
+        }
+        
+        private func setPlaceholder(text: String) {
+            let attributedString = NSAttributedString(
+                string: text,
+                attributes: [
+                    .font: DesignSystemFontFamily.Pretendard.regular.font(size: 14),
+                    .foregroundColor: DesignSystemAsset.Colors.gray40.color
+                ])
+            attributedPlaceholder = attributedString
+        }
+        
+        private func bindEvent() {
+            controlPublisher(for: .editingDidBegin)
+                .withUnretained(self)
+                .sink { owner, _ in
+                    owner.layer.borderWidth = 1
+                }
+                .store(in: &cancellables)
+            
+            controlPublisher(for: .editingDidEnd)
+                .withUnretained(self)
+                .sink { owner, _ in
+                    owner.layer.borderWidth = 0
+                }
+                .store(in: &cancellables)
         }
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuItemCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuItemCell.swift
@@ -12,19 +12,19 @@ final class WriteDetailMenuItemCell: BaseCollectionViewCell {
     
     let nameField = TextField(placeholder: "ex) 슈크림")
     
-    let descriptionField = TextField(placeholder: "ex) 3개 2천원")
+    let priceField = TextField(placeholder: "ex) 3개 2천원")
     
     override func prepareForReuse() {
         super.prepareForReuse()
         
         nameField.text = nil
-        descriptionField.text = nil
+        priceField.text = nil
     }
     
     override func setup() {
         contentView.addSubViews([
             nameField,
-            descriptionField
+            priceField
         ])
     }
     
@@ -36,12 +36,33 @@ final class WriteDetailMenuItemCell: BaseCollectionViewCell {
             $0.width.equalTo(Layout.nameWidth)
         }
         
-        descriptionField.snp.makeConstraints {
+        priceField.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.bottom.equalToSuperview()
             $0.right.equalToSuperview()
             $0.left.equalTo(nameField.snp.right).offset(Layout.space)
         }
+    }
+    
+    func bind(viewModel: WriteDetailMenuGroupViewModel?, index: Int) {
+        guard let viewModel = viewModel else { return }
+        
+        nameField.text = viewModel.output.menus[safe: index]?.name
+        priceField.text = viewModel.output.menus[safe: index]?.price
+        
+        nameField.publisher(for: \.text)
+            .dropFirst()
+            .map { $0 ?? "" }
+            .map { (index, $0) }
+            .subscribe(viewModel.input.inputMenuName)
+            .store(in: &cancellables)
+        
+        priceField.publisher(for: \.text)
+            .dropFirst()
+            .map { $0 ?? "" }
+            .map { (index, $0) }
+            .subscribe(viewModel.input.inputMenuPrice)
+            .store(in: &cancellables)
     }
 }
 

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuItemCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailMenuItemCell.swift
@@ -1,0 +1,74 @@
+import UIKit
+
+import DesignSystem
+
+final class WriteDetailMenuItemCell: BaseCollectionViewCell {
+    enum Layout {
+        static let size = CGSize(width: UIScreen.main.bounds.width - 40 - 24, height: 44)
+        static let space: CGFloat = 12
+        static let nameWidth = (size.width - space) * 0.3
+    }
+    
+    let nameField = TextField(placeholder: "ex) 슈크림")
+    
+    let descriptionField = TextField(placeholder: "ex) 3개 2천원")
+    
+    override func setup() {
+        contentView.addSubViews([
+            nameField,
+            descriptionField
+        ])
+    }
+    
+    override func bindConstraints() {
+        nameField.snp.makeConstraints {
+            $0.left.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.width.equalTo(Layout.nameWidth)
+        }
+        
+        descriptionField.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.right.equalToSuperview()
+            $0.left.equalTo(nameField.snp.right).offset(Layout.space)
+        }
+    }
+}
+
+extension WriteDetailMenuItemCell {
+    final class TextField: UITextField {
+        init(placeholder: String? = nil) {
+            super.init(frame: .zero)
+            
+            setup()
+            
+            if let placeholder = placeholder {
+                let attributedString = NSAttributedString(
+                    string: placeholder,
+                    attributes: [
+                        .font: DesignSystemFontFamily.Pretendard.regular.font(size: 14),
+                        .foregroundColor: DesignSystemAsset.Colors.gray40.color
+                    ])
+                attributedPlaceholder = attributedString
+            }
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+        private func setup() {
+            layer.cornerRadius = 12
+            layer.borderWidth = 1
+            layer.borderColor = DesignSystemAsset.Colors.mainPink.color.cgColor
+            leftView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 44))
+            leftViewMode = .always
+            rightView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 44))
+            rightViewMode = .always
+            font = DesignSystemFontFamily.Pretendard.regular.font(size: 14)
+            backgroundColor = DesignSystemAsset.Colors.gray10.color
+        }
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailNameCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailNameCell.swift
@@ -15,8 +15,8 @@ final class WriteDetailNameCell: BaseCollectionViewCell {
     
     let nameField = UITextField().then {
         $0.font = DesignSystemFontFamily.Pretendard.regular.font(size: 14)
-        $0.textColor = DesignSystemAsset.Colors.gray50.color
-        $0.placeholder = "플레이스 홀더"
+        $0.textColor = DesignSystemAsset.Colors.gray100.color
+        $0.attributedPlaceholder = NSAttributedString(string: ThreeDollarInMyPocketStrings.writeDetailNamePlaceholer, attributes: [.foregroundColor: DesignSystemAsset.Colors.gray50.color])
     }
     
     override func setup() {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailNameCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailNameCell.swift
@@ -13,7 +13,7 @@ final class WriteDetailNameCell: BaseCollectionViewCell {
         $0.layer.masksToBounds = true
     }
     
-    private let nameField = UITextField().then {
+    let nameField = UITextField().then {
         $0.font = DesignSystemFontFamily.Pretendard.regular.font(size: 14)
         $0.textColor = DesignSystemAsset.Colors.gray50.color
         $0.placeholder = "플레이스 홀더"

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailNameCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailNameCell.swift
@@ -17,9 +17,12 @@ final class WriteDetailNameCell: BaseCollectionViewCell {
         $0.font = DesignSystemFontFamily.Pretendard.regular.font(size: 14)
         $0.textColor = DesignSystemAsset.Colors.gray100.color
         $0.attributedPlaceholder = NSAttributedString(string: ThreeDollarInMyPocketStrings.writeDetailNamePlaceholer, attributes: [.foregroundColor: DesignSystemAsset.Colors.gray50.color])
+        $0.returnKeyType = .done
     }
     
     override func setup() {
+        backgroundColor = DesignSystemAsset.Colors.systemWhite.color
+        nameField.delegate = self
         contentView.addSubViews([
             containerView,
             nameField
@@ -39,5 +42,12 @@ final class WriteDetailNameCell: BaseCollectionViewCell {
             $0.right.equalTo(containerView).offset(-12)
             $0.centerY.equalTo(containerView)
         }
+    }
+}
+
+extension WriteDetailNameCell: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return false
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailNameCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailNameCell.swift
@@ -43,6 +43,10 @@ final class WriteDetailNameCell: BaseCollectionViewCell {
             $0.centerY.equalTo(containerView)
         }
     }
+    
+    func bind(name: String) {
+        nameField.text = name
+    }
 }
 
 extension WriteDetailNameCell: UITextFieldDelegate {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailPaymentCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailPaymentCell.swift
@@ -21,8 +21,8 @@ final class WriteDetailPaymentCell: BaseCollectionViewCell {
     
     override func bindConstraints() {
         paymentStackView.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(20)
-            $0.right.equalToSuperview().offset(-20)
+            $0.left.equalToSuperview().offset(20).priority(.high)
+            $0.right.equalToSuperview().offset(-20).priority(.high)
             $0.top.equalToSuperview()
             $0.bottom.equalToSuperview().offset(-16)
         }
@@ -95,15 +95,15 @@ extension WriteDetailPaymentCell {
         
         private func bindConstraints() {
             cashCheckButton.snp.makeConstraints {
-                $0.size.equalTo(Layout.size)
+                $0.size.equalTo(Layout.size).priority(.high)
             }
             
             cardCheckButton.snp.makeConstraints {
-                $0.size.equalTo(Layout.size)
+                $0.size.equalTo(Layout.size).priority(.high)
             }
             
             transferCheckButton.snp.makeConstraints {
-                $0.size.equalTo(Layout.size)
+                $0.size.equalTo(Layout.size).priority(.high)
             }
         }
     }
@@ -140,7 +140,7 @@ extension WriteDetailPaymentCell {
             if let titleLabel = titleLabel {
                 imageView?.snp.makeConstraints {
                     $0.centerY.equalTo(titleLabel)
-                    $0.right.equalTo(titleLabel.snp.left).offset(-4)
+                    $0.right.equalTo(titleLabel.snp.left).offset(-4).priority(.high)
                     $0.width.height.equalTo(16)
                 }
             }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailPaymentCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailPaymentCell.swift
@@ -15,6 +15,7 @@ final class WriteDetailPaymentCell: BaseCollectionViewCell {
     private let paymentStackView = WriteDetailPaymentStackView()
     
     override func setup() {
+        backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         contentView.addSubview(paymentStackView)
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailTypeCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailTypeCell.swift
@@ -15,6 +15,7 @@ final class WriteDetailTypeCell: BaseCollectionViewCell {
     private let typeStackView = WriteDetailTypeStackView()
     
     override func setup() {
+        backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         contentView.addSubview(typeStackView)
     }
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailTypeCell.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/writing/write-detail/cells/WriteDetailTypeCell.swift
@@ -1,10 +1,15 @@
 import UIKit
+import Combine
 
 import DesignSystem
 
 final class WriteDetailTypeCell: BaseCollectionViewCell {
     enum Layout {
         static let size = CGSize(width: UIScreen.main.bounds.width, height: 60)
+    }
+    
+    var tapPublisher: PassthroughSubject<StreetFoodStoreType, Never> {
+        return typeStackView.tapPublisher
     }
     
     private let typeStackView = WriteDetailTypeStackView()
@@ -16,6 +21,7 @@ final class WriteDetailTypeCell: BaseCollectionViewCell {
     override func bindConstraints() {
         typeStackView.snp.makeConstraints {
             $0.left.equalToSuperview().offset(20)
+            $0.right.equalToSuperview().offset(-20)
             $0.top.equalToSuperview()
             $0.bottom.equalToSuperview().offset(-16)
         }
@@ -25,9 +31,11 @@ final class WriteDetailTypeCell: BaseCollectionViewCell {
 extension WriteDetailTypeCell {
     final class WriteDetailTypeStackView: UIStackView {
         enum Layout {
-            static let size = CGSize(width: 90, height: 36)
+            static let height: CGFloat = 36
             static let space: CGFloat = 8
         }
+        
+        let tapPublisher = PassthroughSubject<StreetFoodStoreType, Never>()
         
         let roadRadioButton = TypeRadioButton(title: ThreeDollarInMyPocketStrings.storeTypeRoad)
         
@@ -35,11 +43,13 @@ extension WriteDetailTypeCell {
         
         let convenienceStoreRadioButton = TypeRadioButton(title: ThreeDollarInMyPocketStrings.storeTypeConvenienceStore)
         
+        var cancellables = Set<AnyCancellable>()
+        
         override init(frame: CGRect) {
             super.init(frame: frame)
             
-            self.setup()
-            self.bindConstraints()
+            setup()
+            bindConstraints()
         }
         
         required init(coder: NSCoder) {
@@ -47,39 +57,64 @@ extension WriteDetailTypeCell {
         }
         
         func selectType(type: StreetFoodStoreType?) {
-            self.clearSelect()
+            clearSelect()
             
             if let type = type {
                 let index = type.getIndexValue()
                 
-                if let button = self.arrangedSubviews[index] as? UIButton {
+                if let button = arrangedSubviews[index] as? UIButton {
                     button.isSelected = true
                 }
             }
         }
         
         private func setup() {
-            self.alignment = .leading
-            self.axis = .horizontal
-            self.backgroundColor = .clear
-            self.spacing = Layout.space
+            alignment = .center
+            axis = .horizontal
+            backgroundColor = .clear
+            spacing = Layout.space
+            distribution = .fillEqually
             
-            self.addArrangedSubview(roadRadioButton)
-            self.addArrangedSubview(storeRadioButton)
-            self.addArrangedSubview(convenienceStoreRadioButton)
+            addArrangedSubview(roadRadioButton)
+            addArrangedSubview(storeRadioButton)
+            addArrangedSubview(convenienceStoreRadioButton)
+            
+            roadRadioButton.controlPublisher(for: .touchUpInside)
+                .withUnretained(self)
+                .sink(receiveValue: { owner, _ in
+                    owner.selectType(type: .road)
+                    owner.tapPublisher.send(.road)
+                })
+                .store(in: &cancellables)
+            
+            storeRadioButton.controlPublisher(for: .touchUpInside)
+                .withUnretained(self)
+                .sink(receiveValue: { owner, _ in
+                    owner.selectType(type: .store)
+                    owner.tapPublisher.send(.store)
+                })
+                .store(in: &cancellables)
+            
+            convenienceStoreRadioButton.controlPublisher(for: .touchUpInside)
+                .withUnretained(self)
+                .sink(receiveValue: { owner, _ in
+                    owner.selectType(type: .convenienceStore)
+                    owner.tapPublisher.send(.convenienceStore)
+                })
+                .store(in: &cancellables)
         }
         
         private func bindConstraints() {
-            self.roadRadioButton.snp.makeConstraints {
-                $0.size.equalTo(Layout.size)
+            roadRadioButton.snp.makeConstraints {
+                $0.height.equalTo(Layout.height)
             }
             
-            self.storeRadioButton.snp.makeConstraints {
-                $0.size.equalTo(Layout.size)
+            storeRadioButton.snp.makeConstraints {
+                $0.height.equalTo(Layout.height)
             }
             
-            self.convenienceStoreRadioButton.snp.makeConstraints {
-                $0.size.equalTo(Layout.size)
+            convenienceStoreRadioButton.snp.makeConstraints {
+                $0.height.equalTo(Layout.height)
             }
         }
         
@@ -97,6 +132,7 @@ extension WriteDetailTypeCell {
             didSet {
                 layer.borderColor = isSelected ? DesignSystemAsset.Colors.mainPink.color.cgColor : DesignSystemAsset.Colors.gray30.color.cgColor
                 tintColor = isSelected ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
+                dotImage.backgroundColor = isSelected ? DesignSystemAsset.Colors.mainPink.color : DesignSystemAsset.Colors.gray30.color
             }
         }
         
@@ -117,6 +153,8 @@ extension WriteDetailTypeCell {
         
         private func setupUI(title: String) {
             setTitle(title, for: .normal)
+            contentEdgeInsets = .init(top: 0, left: 4, bottom: 0, right: 0)
+            titleEdgeInsets = .init(top: 0, left: 4, bottom: 0, right: 0)
             
             addSubview(dotImage)
             if let titleLabel = titleLabel {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/extension/StringExtension.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/extension/StringExtension.swift
@@ -1,8 +1,11 @@
 import Foundation
 
 extension String {
-  
-  var localized: String {
-    return NSLocalizedString(self, tableName: "Localization", value: self, comment: "")
-  }
+    var localized: String {
+        return NSLocalizedString(self, tableName: "Localization", value: self, comment: "")
+    }
+    
+    var isNotEmpty: Bool {
+        return !isEmpty
+    }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsEvent.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsEvent.swift
@@ -17,6 +17,9 @@ enum AnalyticsEvent {
     /// category-selection 카테고리 선택 화면
     case clickSelectCategory(categoryIds: [String])
     
+    /// write-detail
+    case clickSave
+    
     var name: String {
         switch self {
         case .splashPopupClicked:
@@ -48,6 +51,9 @@ enum AnalyticsEvent {
             
         case .clickSelectCategory:
             return "click_select_category"
+            
+        case .clickSave:
+            return "click_save"
         }
     }
     
@@ -82,6 +88,9 @@ enum AnalyticsEvent {
             
         case .clickSelectCategory(let categoryIds):
             return ["category_id": categoryIds]
+            
+        case .clickSave:
+            return [:]
         }
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsScreen.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/manager/analytics/AnalyticsScreen.swift
@@ -13,6 +13,7 @@ enum AnalyticsScreen: String {
     /// 제보 주소 화면
     case writeAddress = "write_address"
     case writeAddressPopup = "write_address_popop"
+    case writeAddressDetail = "write_address_detail"
     
     case categorySelection = "category_selection"
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/manager/metadata/MetadataManager.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/manager/metadata/MetadataManager.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+import Networking
+
+final class MetadataManager {
+    static let shared = MetadataManager()
+    
+    private let categoryService: Networking.CategoryServiceProtocol
+    
+    var categories: [PlatformStoreCategory] = []
+    
+    init(categoryService: Networking.CategoryServiceProtocol = Networking.CategoryService()) {
+        self.categoryService = categoryService
+    }
+    
+    func fetchCategories() {
+        Task {
+            let result = await categoryService.fetchCategoires()
+            
+            switch result {
+            case .success(let categoryResponse):
+                let resultCategories = categoryResponse.map { PlatformStoreCategory(response: $0) }
+                categories = resultCategories
+                
+            case .failure(_):
+                break
+            }
+        }
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/DayOfTheWeek.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/DayOfTheWeek.swift
@@ -1,5 +1,5 @@
 enum DayOfTheWeek: String {
-    case monday = "MONEDAY"
+    case monday = "MONDAY"
     case tuesday = "TUESDAY"
     case wednesday = "WEDNESDAY"
     case thursday = "THURSDAY"

--- a/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/Location.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/Location.swift
@@ -1,4 +1,4 @@
-struct Location {
+struct Location: Hashable {
     let latitude: Double
     let longitude: Double
     

--- a/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/Menu.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/Menu.swift
@@ -1,25 +1,34 @@
-struct Menu {
-  
-  let category: StreetFoodStoreCategory
-  let menuId: Int
-  var name: String
-  var price: String
-  
-  init(
-    category: StreetFoodStoreCategory,
-    name: String = "",
-    price: String = ""
-  ) {
-    self.category = category
-    self.menuId = 0
-    self.name = name
-    self.price = price
-  }
-  
-  init(response: MenuResponse) {
-    self.category = response.category
-    self.menuId = response.menuId
-    self.name = response.name
-    self.price = response.price
-  }
+struct Menu: Hashable {
+    let category: StreetFoodStoreCategory
+    let menuId: Int
+    var name: String
+    var price: String
+    
+    init(
+        category: StreetFoodStoreCategory,
+        name: String = "",
+        price: String = ""
+    ) {
+        self.category = category
+        self.menuId = 0
+        self.name = name
+        self.price = price
+    }
+    
+    init(response: MenuResponse) {
+        self.category = response.category
+        self.menuId = response.menuId
+        self.name = response.name
+        self.price = response.price
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+    }
+}
+
+extension Menu {
+    var isValid: Bool {
+        return name.isNotEmpty
+    }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/NewMenu.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/NewMenu.swift
@@ -1,0 +1,21 @@
+struct NewMenu: Hashable {
+    let category: PlatformStoreCategory
+    var name: String
+    var price: String
+    
+    init(
+        category: PlatformStoreCategory,
+        name: String = "",
+        price: String = ""
+    ) {
+        self.category = category
+        self.name = name
+        self.price = price
+    }
+}
+
+extension NewMenu {
+    var isValid: Bool {
+        return name.isNotEmpty && price.isNotEmpty
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/NewStore.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/NewStore.swift
@@ -1,0 +1,9 @@
+struct NewStore {
+    var name: String
+    var latitude: Double
+    var longitude: Double
+    var storeType: StreetFoodStoreType
+    var appearanceDays: [WeekDay]
+    var paymentMethods: [PaymentType]
+//    var menus: [StoreMenuRequestInput]
+}

--- a/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/PaymentType.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/PaymentType.swift
@@ -1,13 +1,13 @@
 enum PaymentType: String, Codable {
-  case cash = "CASH"
-  case card = "CARD"
-  case transfer = "ACCOUNT_TRANSFER"
-  
-  func getIndexValue() -> Int {
-    switch self {
-    case .cash: return 0
-    case .card: return 1
-    case .transfer: return 2
+    case cash = "CASH"
+    case card = "CARD"
+    case transfer = "ACCOUNT_TRANSFER"
+    
+    func getIndexValue() -> Int {
+        switch self {
+        case .cash: return 0
+        case .card: return 1
+        case .transfer: return 2
+        }
     }
-  }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/StreetFoodStoreType.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/model/presentation/StreetFoodStoreType.swift
@@ -1,21 +1,21 @@
 enum StreetFoodStoreType: String, Codable {
-  case road = "ROAD"
-  case store = "STORE"
-  case convenienceStore = "CONVENIENCE_STORE"
-  
-  func getIndexValue() -> Int {
-    switch self {
-    case .road: return 0
-    case .store: return 1
-    case .convenienceStore: return 2
+    case road = "ROAD"
+    case store = "STORE"
+    case convenienceStore = "CONVENIENCE_STORE"
+    
+    func getIndexValue() -> Int {
+        switch self {
+        case .road: return 0
+        case .store: return 1
+        case .convenienceStore: return 2
+        }
     }
-  }
-  
-  func getString() -> String {
-    switch self {
-    case .road: return "shared_store_type_road".localized
-    case .store: return "shared_store_type_store".localized
-    case .convenienceStore: return "shared_store_type_convenience_store".localized
+    
+    func getString() -> String {
+        switch self {
+        case .road: return "shared_store_type_road".localized
+        case .store: return "shared_store_type_store".localized
+        case .convenienceStore: return "shared_store_type_convenience_store".localized
+        }
     }
-  }
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       rexml (~> 3.2.4)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/Modules/Network/Sources/APIBase/Manager/RequestProvider.swift
+++ b/Modules/Network/Sources/APIBase/Manager/RequestProvider.swift
@@ -48,6 +48,7 @@ final class RequestProvider {
     private func generateHeader(type: HTTPHeaderType) -> [String: String] {
         var header = [
             "Accept": "application/json",
+            "Content-Type": "application/json",
             "User-Agent": config.userAgent
         ]
         

--- a/Modules/Network/Sources/APIBase/Model/RequestType.swift
+++ b/Modules/Network/Sources/APIBase/Model/RequestType.swift
@@ -19,7 +19,7 @@ extension RequestType {
     
     var body: Data? {
         guard let param = param,
-              let data = try? JSONSerialization.data(withJSONObject: param, options: []) else {
+              let data = try? JSONEncoder().encode(param) else {
             return nil
         }
         

--- a/Modules/Network/Sources/APIBase/Model/RequestType.swift
+++ b/Modules/Network/Sources/APIBase/Model/RequestType.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public protocol RequestType {
-    var param: [String: Any]? { get }
+    var param: Encodable? { get }
     var method: RequestMethod { get }
     var header: HTTPHeaderType { get }
     var path: String { get }
@@ -9,8 +9,9 @@ public protocol RequestType {
 
 extension RequestType {
     var queryItems: [URLQueryItem]? {
-        if let param = param {
-            return param.map { URLQueryItem(name: $0.key, value: String(describing: $0.value)) }
+        if let param = param,
+           let dictionary = param.dictionary {
+            return dictionary.map { URLQueryItem(name: $0.key, value: String(describing: $0.value)) }
         } else {
             return nil
         }

--- a/Modules/Network/Sources/APIs/Input/StoreCreateRequestInput.swift
+++ b/Modules/Network/Sources/APIs/Input/StoreCreateRequestInput.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct StoreCreateRequestInput: Encodable {
+    let latitude: Double
+    let longitude: Double
+    let storeName: String
+    let storeType: String
+    let appearanceDays: [String]
+    let paymentMethods: [String]
+    let menus: [StoreMenuRequestInput]
+}

--- a/Modules/Network/Sources/APIs/Input/StoreCreateRequestInput.swift
+++ b/Modules/Network/Sources/APIs/Input/StoreCreateRequestInput.swift
@@ -4,8 +4,26 @@ public struct StoreCreateRequestInput: Encodable {
     let latitude: Double
     let longitude: Double
     let storeName: String
-    let storeType: String
+    let storeType: String?
     let appearanceDays: [String]
     let paymentMethods: [String]
     let menus: [StoreMenuRequestInput]
+    
+    public init(
+        latitude: Double,
+        longitude: Double,
+        storeName: String,
+        storeType: String?,
+        appearanceDays: [String],
+        paymentMethods: [String],
+        menus: [StoreMenuRequestInput]
+    ) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.storeName = storeName
+        self.storeType = storeType
+        self.appearanceDays = appearanceDays
+        self.paymentMethods = paymentMethods
+        self.menus = menus
+    }
 }

--- a/Modules/Network/Sources/APIs/Input/StoreMenuRequestInput.swift
+++ b/Modules/Network/Sources/APIs/Input/StoreMenuRequestInput.swift
@@ -4,4 +4,10 @@ public struct StoreMenuRequestInput: Encodable {
     let name: String
     let price: String
     let category: [String]
+    
+    public init(name: String, price: String, category: [String]) {
+        self.name = name
+        self.price = price
+        self.category = category
+    }
 }

--- a/Modules/Network/Sources/APIs/Input/StoreMenuRequestInput.swift
+++ b/Modules/Network/Sources/APIs/Input/StoreMenuRequestInput.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct StoreMenuRequestInput: Encodable {
+    let name: String
+    let price: String
+    let category: [String]
+}

--- a/Modules/Network/Sources/APIs/Input/StoreMenuRequestInput.swift
+++ b/Modules/Network/Sources/APIs/Input/StoreMenuRequestInput.swift
@@ -3,9 +3,9 @@ import Foundation
 public struct StoreMenuRequestInput: Encodable {
     let name: String
     let price: String
-    let category: [String]
+    let category: String
     
-    public init(name: String, price: String, category: [String]) {
+    public init(name: String, price: String, category: String) {
         self.name = name
         self.price = price
         self.category = category

--- a/Modules/Network/Sources/APIs/Request/FetchCategoryRequest.swift
+++ b/Modules/Network/Sources/APIs/Request/FetchCategoryRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct FetchCategoryRequest: RequestType {
-    var param: [String : Any]? {
+    var param: Encodable? {
         return nil
     }
     

--- a/Modules/Network/Sources/APIs/Request/IsStoreExistNearbyRequest.swift
+++ b/Modules/Network/Sources/APIs/Request/IsStoreExistNearbyRequest.swift
@@ -5,7 +5,7 @@ struct IsStoreExistNearbyRequest: RequestType {
     let distance: Double
     let mapLocation: CLLocation
     
-    var param: [String : Any]? {
+    var param: Encodable? {
         return [
             "distance": distance,
             "mapLatitude": mapLocation.coordinate.latitude,

--- a/Modules/Network/Sources/APIs/Request/StoreCreateRequest.swift
+++ b/Modules/Network/Sources/APIs/Request/StoreCreateRequest.swift
@@ -11,6 +11,10 @@ struct StoreCreateRequest: RequestType {
         return .post
     }
     
+    var header: HTTPHeaderType {
+        return .auth
+    }
+    
     var path: String {
         return "/api/v2/store"
     }

--- a/Modules/Network/Sources/APIs/Request/StoreCreateRequest.swift
+++ b/Modules/Network/Sources/APIs/Request/StoreCreateRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct StoreCreateRequest: RequestType {
+    let requestInput: StoreCreateRequestInput
+
+    var param: Encodable? {
+        return requestInput
+    }
+    
+    var method: RequestMethod {
+        return .post
+    }
+    
+    var path: String {
+        return "/api/v2/store"
+    }
+}

--- a/Modules/Network/Sources/APIs/Response/AddressResponse.swift
+++ b/Modules/Network/Sources/APIs/Response/AddressResponse.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public struct AddressResponse: Decodable {
+    let fullAddress: String
+}

--- a/Modules/Network/Sources/APIs/Response/StoreCreateResponse.swift
+++ b/Modules/Network/Sources/APIs/Response/StoreCreateResponse.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public struct StoreCategoryResponse: Decodable {
+    let storeId: Int
+    let userId: Int
+    let storeName: String
+    let salesType: String
+    let latitude: Double
+    let longitude: Double
+    let address: AddressResponse
+    let rating: Double
+    let isDeleted: Bool
+    let categories: [String]
+    let createdAt: String?
+    let updatedAt: String?
+}

--- a/Modules/Network/Sources/APIs/StoreService.swift
+++ b/Modules/Network/Sources/APIs/StoreService.swift
@@ -3,6 +3,8 @@ import CoreLocation
 
 public protocol StoreServiceProtocol {
     func isStoresExistedAround(distance: Double, mapLocation: CLLocation) async -> Result<IsStoresExistedAroundResponse, Error>
+    
+    func createStore(input: StoreCreateRequestInput) async -> Result<StoreCategoryResponse, Error>
 }
 
 public struct StoreService: StoreServiceProtocol {
@@ -10,6 +12,12 @@ public struct StoreService: StoreServiceProtocol {
     
     public func isStoresExistedAround(distance: Double, mapLocation: CLLocation) async -> Result<IsStoresExistedAroundResponse, Error> {
         let request = IsStoreExistNearbyRequest(distance: distance, mapLocation: mapLocation)
+        
+        return await NetworkManager.shared.request(requestType: request)
+    }
+    
+    public func createStore(input: StoreCreateRequestInput) async -> Result<StoreCategoryResponse, Error> {
+        let request = StoreCreateRequest(requestInput: input)
         
         return await NetworkManager.shared.request(requestType: request)
     }

--- a/Modules/Network/Sources/Extension/EncodableExtensions.swift
+++ b/Modules/Network/Sources/Extension/EncodableExtensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Encodable {
+    subscript(key: String) -> Any? {
+        return dictionary?[key]
+    }
+    
+    var dictionary: [String: Any]? {
+        return (try? JSONSerialization.jsonObject(with: JSONEncoder().encode(self))) as? [String: Any]
+    }
+}


### PR DESCRIPTION
### 모듈별 변경사항
- 앱 프로젝트
    - 제보하기 상세화면 뷰, 뷰모델 구현
    - 제보하기 상세화면 로그 적용
- 네트워크 모듈
    -  가게 제보하기 API 추가

### 테스트
- 시뮬, 디바이스 모두 가능합니다.

<img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/assets/7058293/36b2771f-eebd-4edd-a530-fd740fb48cee" width=360>

### 테스트 케이스
- 가게 제보화면의 레이아웃이 정상적으로 노출되는가?
- 케이스 별로 가게 등록이 정상적으로 되는가?
    - (최소) 이름, 카테고리만 넣고 등록 가능한가?
    - 최소 조건 + 케이스별로 입력 후 등록 가능한가?

### ⚠️ 안내
- 화면 볼륨이 커서 뷰컨와 뷰모델을 중심으로 보시면 좋을 듯 합니다!