### PR TITLE
홈 화면 카테고리 화면 구현

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -109,15 +109,6 @@
       }
     },
     {
-      "identity" : "lottie-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-ios.git",
-      "state" : {
-        "revision" : "a4622b4d6fdbe76cc5487bc27e84029abaf07217",
-        "version" : "4.0.1"
-      }
-    },
-    {
       "identity" : "nanopb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",

--- a/Modules/Common/Sources/Extension/UICollectionViewDiffableDataSourceExtension.swift
+++ b/Modules/Common/Sources/Extension/UICollectionViewDiffableDataSourceExtension.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+public extension UICollectionViewDiffableDataSource {
+    func sectionIdentifier(section: Int) -> SectionIdentifierType? {
+        if #available(iOS 15.0, *) {
+            return sectionIdentifier(for: section)
+        } else {
+            return snapshot().sectionIdentifiers[safe: section]
+        }
+    }
+    
+    subscript(indexPath: IndexPath) -> ItemIdentifierType? {
+        if #available(iOS 15.0, *) {
+            return itemIdentifier(for: indexPath)
+        } else {
+            let snapshot = self.snapshot()
+            if let section = snapshot.sectionIdentifiers[safe: indexPath.section] {
+                return self.snapshot().itemIdentifiers(inSection: section)[safe: indexPath.item]
+            }
+            return nil
+        }
+    }
+}

--- a/Modules/Common/Sources/Extension/UIColorExtension.swift
+++ b/Modules/Common/Sources/Extension/UIColorExtension.swift
@@ -1,0 +1,37 @@
+import UIKit
+
+public extension UIColor {
+    convenience init?(hex: String) {
+        let red, green, blue, alpha: CGFloat
+        
+        if hex.hasPrefix("#") {
+            let start = hex.index(hex.startIndex, offsetBy: 1)
+            let hexColor = String(hex[start...])
+            
+            let scanner = Scanner(string: hexColor)
+            var hexNumber: UInt64 = 0
+            
+            if scanner.scanHexInt64(&hexNumber) {
+                if hexColor.count == 8 {
+                    red = CGFloat((hexNumber & 0xff000000) >> 24) / 255
+                    green = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
+                    blue = CGFloat((hexNumber & 0x0000ff00) >> 8) / 255
+                    alpha = CGFloat(hexNumber & 0x000000ff) / 255
+                    
+                    self.init(red: red, green: green, blue: blue, alpha: alpha)
+                    return
+                }
+                
+                if hexColor.count == 6 {
+                    red   = CGFloat((hexNumber & 0xff0000) >> 16) / 255.0
+                    green = CGFloat((hexNumber & 0x00ff00) >> 8) / 255.0
+                    blue  = CGFloat(hexNumber & 0x0000ff) / 255.0
+                    
+                    self.init(red: red, green: green, blue: blue, alpha: 1)
+                    return
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Modules/Common/Sources/Extension/UILabelExtension.swift
+++ b/Modules/Common/Sources/Extension/UILabelExtension.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+public extension UILabel {
+    func setKern(kern: Float) {
+        guard let text = text else { return }
+        let attributedString = NSMutableAttributedString(string: text)
+        
+        attributedString.addAttribute(
+            .kern,
+            value: kern,
+            range: .init(location: 0, length: text.count)
+        )
+        attributedText = attributedString
+    }
+    
+    func setLineHeight(lineHeight: CGFloat) {
+        guard let text = text else { return }
+        let style = NSMutableParagraphStyle()
+        
+        style.maximumLineHeight = lineHeight
+        style.minimumLineHeight = lineHeight
+        
+        let attributedString = NSMutableAttributedString(
+            string: text,
+            attributes: [.paragraphStyle: style]
+        )
+        
+        attributedText = attributedString
+    }
+}

--- a/Modules/Feature/Home/Derived/Sources/TuistAssets+Home.swift
+++ b/Modules/Feature/Home/Derived/Sources/TuistAssets+Home.swift
@@ -1,0 +1,69 @@
+// swiftlint:disable all
+// swift-format-ignore-file
+// swiftformat:disable all
+// Generated using tuist — https://github.com/tuist/tuist
+
+#if os(macOS)
+  import AppKit
+#elseif os(iOS)
+  import UIKit
+#elseif os(tvOS) || os(watchOS)
+  import UIKit
+#endif
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Asset Catalogs
+
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+public enum HomeAsset {
+  public static let iconMarkerFocused = HomeImages(name: "icon_marker_focused")
+  public static let iconMarkerUnfocused = HomeImages(name: "icon_marker_unfocused")
+  public static let imageEmptyCategory = HomeImages(name: "image_empty_category")
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+public struct HomeImages {
+  public fileprivate(set) var name: String
+
+  #if os(macOS)
+  public typealias Image = NSImage
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  public typealias Image = UIImage
+  #endif
+
+  public var image: Image {
+    let bundle = HomeResources.bundle
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    let image = bundle.image(forResource: NSImage.Name(name))
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+}
+
+public extension HomeImages.Image {
+  @available(macOS, deprecated,
+    message: "This initializer is unsafe on macOS, please use the HomeImages.image property")
+  convenience init?(asset: HomeImages) {
+    #if os(iOS) || os(tvOS)
+    let bundle = HomeResources.bundle
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+// swiftlint:enable all
+// swiftformat:enable all

--- a/Modules/Feature/Home/Derived/Sources/TuistBundle+Home.swift
+++ b/Modules/Feature/Home/Derived/Sources/TuistBundle+Home.swift
@@ -1,0 +1,26 @@
+// swiftlint:disable all
+// swift-format-ignore-file
+// swiftformat:disable all
+import Foundation
+
+// MARK: - Swift Bundle Accessor
+
+private class BundleFinder {}
+
+extension Foundation.Bundle {
+    /// Since Home is a framework, the bundle for classes within this module can be used directly.
+    static var module: Bundle = {
+        return Bundle(for: BundleFinder.self)
+    }()
+}
+
+// MARK: - Objective-C Bundle Accessor
+
+@objc
+public class HomeResources: NSObject {
+   @objc public class var bundle: Bundle {
+         return .module
+   }
+}
+// swiftlint:enable all
+// swiftformat:enable all

--- a/Modules/Feature/Home/Derived/Sources/TuistStrings+Home.swift
+++ b/Modules/Feature/Home/Derived/Sources/TuistStrings+Home.swift
@@ -1,0 +1,48 @@
+// swiftlint:disable all
+// swift-format-ignore-file
+// swiftformat:disable all
+// Generated using tuist — https://github.com/tuist/tuist
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Strings
+
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
+public enum HomeStrings {
+  /// 전체 메뉴
+  public static let homeCategoryFilterButton = HomeStrings.tr("Localization", "home_category_filter_button")
+  /// 다른 주소로 검색하거나 직접 제보해보세요!
+  public static let homeEmptyDescription = HomeStrings.tr("Localization", "home_empty_description")
+  /// 주변 2km 이내에\n가게가 없어요.
+  public static let homeEmptyTitle = HomeStrings.tr("Localization", "home_empty_title")
+  /// 리스트뷰
+  public static let homeListViewButton = HomeStrings.tr("Localization", "home_list_view_button")
+  /// 사장님 직영점만
+  public static let homeOnlyBossButton = HomeStrings.tr("Localization", "home_only_boss_button")
+  /// 현재 지도에서 가게 재검색
+  public static let homeResearchButton = HomeStrings.tr("Localization", "home_research_button")
+  /// 거리순 보기
+  public static let homeSortingButtonDistance = HomeStrings.tr("Localization", "home_sorting_button_distance")
+  /// 최근 등록순 보기
+  public static let homeSortingButtonLatest = HomeStrings.tr("Localization", "home_sorting_button_latest")
+  /// 방문하기
+  public static let homeVisitButton = HomeStrings.tr("Localization", "home_visit_button")
+}
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+extension HomeStrings {
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
+    let format = HomeResources.bundle.localizedString(forKey: key, value: nil, table: table)
+    return String(format: format, locale: Locale.current, arguments: args)
+  }
+}
+
+// swiftlint:disable convenience_type
+// swiftlint:enable all
+// swiftformat:enable all

--- a/Modules/Feature/Home/Project.swift
+++ b/Modules/Feature/Home/Project.swift
@@ -41,6 +41,7 @@ let project = Project(
                 .project(target: "Common", path: "../../Common"),
                 .external(name: "SnapKit"),
                 .external(name: "Then"),
+                .external(name: "PanModal")
             ]
         )
     ]

--- a/Modules/Feature/Home/Resources/en.lproj/Localization.strings
+++ b/Modules/Feature/Home/Resources/en.lproj/Localization.strings
@@ -1,3 +1,4 @@
+// 홈 화면
 "home_category_filter_button" = "전체 메뉴";
 "home_research_button" = "현재 지도에서 가게 재검색";
 "home_list_view_button" = "리스트뷰";
@@ -7,3 +8,7 @@
 "home_only_boss_button" = "사장님 직영점만";
 "home_sorting_button_distance" = "거리순 보기";
 "home_sorting_button_latest" = "최근 등록순 보기";
+
+// 카테고리 필터 화면
+"category_filter_new" = "new";
+"category_filter_title" = "이 안에 네 최애 하나쯤은 있겠지!";

--- a/Modules/Feature/Home/Resources/en.lproj/Localization.strings
+++ b/Modules/Feature/Home/Resources/en.lproj/Localization.strings
@@ -1,0 +1,9 @@
+"home_category_filter_button" = "전체 메뉴";
+"home_research_button" = "현재 지도에서 가게 재검색";
+"home_list_view_button" = "리스트뷰";
+"home_visit_button" = "방문하기";
+"home_empty_title" = "주변 2km 이내에\n가게가 없어요.";
+"home_empty_description" = "다른 주소로 검색하거나 직접 제보해보세요!";
+"home_only_boss_button" = "사장님 직영점만";
+"home_sorting_button_distance" = "거리순 보기";
+"home_sorting_button_latest" = "최근 등록순 보기";

--- a/Modules/Feature/Home/Sources/Domains/CategoryFilter/CategoryFilterDataSource.swift
+++ b/Modules/Feature/Home/Sources/Domains/CategoryFilter/CategoryFilterDataSource.swift
@@ -1,0 +1,62 @@
+import UIKit
+
+typealias CategoryFilterSanpshot = NSDiffableDataSourceSnapshot<CategorySection, CategorySectionItem>
+
+final class CategoryFilterDataSource: UICollectionViewDiffableDataSource<CategorySection, CategorySectionItem> {
+    let viewModel: CategoryFilterViewModel
+    
+    init(collectionView: UICollectionView, viewModel: CategoryFilterViewModel) {
+        self.viewModel = viewModel
+        
+        collectionView.register([
+            CategoryBannerCell.self,
+            CategoryFilterCell.self
+        ])
+        collectionView.register(
+            CategoryFilterHeaderView.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: CategoryFilterHeaderView.registerId
+        )
+        
+        super.init(collectionView: collectionView) { collectionView, indexPath, itemIdentifier in
+            switch itemIdentifier {
+            case .category(let category):
+                let cell: CategoryFilterCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                
+                cell.bind(category: category)
+                return cell
+                
+            case .advertisement(let advertisement):
+                let cell: CategoryBannerCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
+                
+                cell.bind(advertisement: advertisement)
+                return cell
+            }
+        }
+        
+        self.supplementaryViewProvider = { [weak self] collectionView, type, indexPath -> UICollectionReusableView? in
+            guard let section = self?.sectionIdentifier(section: indexPath.section) else { return nil }
+            
+            let headerView = collectionView.dequeueReusableSupplementaryView(
+                ofKind: UICollectionView.elementKindSectionHeader,
+                withReuseIdentifier: CategoryFilterHeaderView.registerId,
+                for: indexPath
+            ) as? CategoryFilterHeaderView
+            
+            headerView?.bind(title: section.title, isFirst: indexPath.section == 0)
+            return headerView
+        }
+        
+        collectionView.delegate = self
+    }
+}
+
+extension CategoryFilterDataSource: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if indexPath.section == 0 {
+            viewModel.input.onTapBanner.send(())
+        } else {
+            viewModel.input.onTapCategory.send(indexPath.row)
+        }
+    }
+}

--- a/Modules/Feature/Home/Sources/Domains/CategoryFilter/CategoryFilterView.swift
+++ b/Modules/Feature/Home/Sources/Domains/CategoryFilter/CategoryFilterView.swift
@@ -1,0 +1,64 @@
+import UIKit
+
+import Common
+
+final class CategoryFilterView: BaseView {
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: generateCollectionLayout())
+    
+    override func setup() {
+        addSubViews([collectionView])
+    }
+    
+    override func bindConstraints() {
+        collectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    private func generateCollectionLayout() -> UICollectionViewLayout {
+        return UICollectionViewCompositionalLayout { sectionIndex, _ in
+            if sectionIndex == 0 {
+                let item = NSCollectionLayoutItem(layoutSize: .init(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .absolute(CategoryBannerCell.size.height)
+                ))
+                let group = NSCollectionLayoutGroup.vertical(layoutSize: .init(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .absolute(CategoryBannerCell.size.height)
+                ), subitems: [item])
+                let section = NSCollectionLayoutSection(group: group)
+                section.contentInsets = .init(top: 0, leading: 24, bottom: 0, trailing: 24)
+                section.boundarySupplementaryItems = [ .init(
+                    layoutSize: .init(
+                        widthDimension: .fractionalWidth(1),
+                        heightDimension: .estimated(CategoryFilterHeaderView.estimatedHeight)),
+                    elementKind: UICollectionView.elementKindSectionHeader,
+                    alignment: .topLeading
+                )]
+                
+                return section
+            } else {
+                let item = NSCollectionLayoutItem(layoutSize: .init(
+                    widthDimension: .absolute(CategoryFilterCell.size.width),
+                    heightDimension: .absolute(CategoryFilterCell.size.height)
+                ))
+                let group = NSCollectionLayoutGroup.horizontal(layoutSize: .init(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .absolute(CategoryFilterCell.size.height)
+                ), subitems: [item])
+                group.interItemSpacing = NSCollectionLayoutSpacing.fixed(13)
+                let section = NSCollectionLayoutSection(group: group)
+                section.contentInsets = .init(top: 0, leading: 24, bottom: 0, trailing: 24)
+                section.boundarySupplementaryItems = [ .init(
+                    layoutSize: .init(
+                        widthDimension: .fractionalWidth(1),
+                        heightDimension: .estimated(CategoryFilterHeaderView.estimatedHeight)),
+                    elementKind: UICollectionView.elementKindSectionHeader,
+                    alignment: .topLeading
+                )]
+                
+                return section
+            }
+        }
+    }
+}

--- a/Modules/Feature/Home/Sources/Domains/CategoryFilter/CategoryFilterViewController.swift
+++ b/Modules/Feature/Home/Sources/Domains/CategoryFilter/CategoryFilterViewController.swift
@@ -1,0 +1,131 @@
+import UIKit
+import Combine
+
+import Common
+import PanModal
+
+protocol CategoryFilterDelegate: AnyObject {
+    func onSelectCategory(category: PlatformStoreCategory?)
+}
+
+final class CategoryFilterViewController: BaseViewController {
+    weak var delegate: CategoryFilterDelegate?
+    private let categoryFilterView = CategoryFilterView()
+    private let viewModel: CategoryFilterViewModel
+    private lazy var dataSource = CategoryFilterDataSource(
+        collectionView: categoryFilterView.collectionView,
+        viewModel: viewModel
+    )
+    
+    static func instance(selectedCategory: PlatformStoreCategory? = nil) -> CategoryFilterViewController {
+        return CategoryFilterViewController(selectedCategory: selectedCategory)
+    }
+    
+    init(selectedCategory: PlatformStoreCategory? = nil) {
+        self.viewModel = CategoryFilterViewModel(category: selectedCategory)
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        view = categoryFilterView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        viewModel.input.viewDidLoad.send(())
+    }
+    
+    override func bindViewModelOutput() {
+        Publishers.Zip(viewModel.output.categories, viewModel.output.advertisement)
+            .withUnretained(self)
+            .receive(on: DispatchQueue.main)
+            .sink { owner, dataSourceItems in
+                var categorySections: [CategorySection] = []
+                let (categories, advertisement) = dataSourceItems
+                let advertisementSectionItems = advertisement == nil ? [] : [CategorySectionItem.advertisement(advertisement)]
+                let advertisementSection = CategorySection(title: "이 안에 네 최애 하나쯤은 있겠지!", items: advertisementSectionItems)
+                
+                categorySections.append(advertisementSection)
+                
+                let groupingByCategoryType = Dictionary(grouping: categories) { $0.classificationType }
+                
+                for categoryType in groupingByCategoryType.keys {
+                    if let categories = groupingByCategoryType[categoryType] {
+                        let categorySection = CategorySection(title: categoryType, items: categories.map { CategorySectionItem.category($0) })
+                        
+                        categorySections.append(categorySection)
+                    }
+                }
+                
+                owner.updateDataSource(section: categorySections)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.output.route
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, route in
+                switch route {
+                case .showErrorAlert(let error):
+                    print("🔥 Common 모듈에 AlertUtils 구현 필요")
+                    
+                case .dismissWithCategory(let category):
+                    owner.delegate?.onSelectCategory(category: category)
+                    owner.dismiss(animated: true)
+                    
+                case .goToWeb(let urlString):
+                    owner.openURLWithSafari(urlString: urlString)
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func updateDataSource(section: [CategorySection]) {
+        var snapshot = CategoryFilterSanpshot()
+        
+        section.forEach {
+            snapshot.appendSections([$0])
+            snapshot.appendItems($0.items)
+        }
+        
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+    private func openURLWithSafari(urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        
+        UIApplication.shared.open(url)
+    }
+}
+
+extension CategoryFilterViewController: PanModalPresentable {
+    var panScrollable: UIScrollView? {
+        categoryFilterView.collectionView
+    }
+    
+    var shortFormHeight: PanModalHeight {
+        return .contentHeight(520)
+    }
+    
+    var longFormHeight: PanModalHeight {
+        return .maxHeight
+    }
+    
+    var panModalBackgroundColor: UIColor {
+        return .clear
+    }
+    
+    var cornerRadius: CGFloat {
+        return 12
+    }
+    
+    var allowsExtendedPanScrolling: Bool {
+        return true
+    }
+}

--- a/Modules/Feature/Home/Sources/Domains/CategoryFilter/CategoryFilterViewModel.swift
+++ b/Modules/Feature/Home/Sources/Domains/CategoryFilter/CategoryFilterViewModel.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Combine
+
+import Common
+import Networking
+
+final class CategoryFilterViewModel: BaseViewModel {
+    struct Input {
+        let viewDidLoad = PassthroughSubject<Void, Never>()
+        let onTapBanner = PassthroughSubject<Void, Never>()
+        let onTapCategory = PassthroughSubject<Int, Never>()
+    }
+    
+    struct Output {
+        let advertisement = PassthroughSubject<Advertisement?, Never>()
+        let categories = PassthroughSubject<[PlatformStoreCategory], Never>()
+        let route = PassthroughSubject<Route, Never>()
+    }
+    
+    struct State {
+        var currentCategory: PlatformStoreCategory?
+        var advertisement: Advertisement?
+        var categories: [PlatformStoreCategory]
+    }
+    
+    enum Route {
+        case showErrorAlert(Error)
+        case dismissWithCategory(PlatformStoreCategory?)
+        case goToWeb(url: String)
+    }
+    
+    let input = Input()
+    let output = Output()
+    private var state: State
+    private let categoryService: CategoryServiceProtocol
+    private let advertisementService: AdvertisementServiceProtocol
+    
+    init(
+        category: PlatformStoreCategory?,
+        categoryService: CategoryServiceProtocol = CategoryService(),
+        advertisementService: AdvertisementServiceProtocol = AdvertisementService()
+    ) {
+        self.state = State(currentCategory: category, advertisement: nil, categories: [])
+        self.categoryService = categoryService
+        self.advertisementService = advertisementService
+        
+        super.init()
+    }
+    
+    override func bind() {
+        let fetchCategories = input.viewDidLoad
+            .withUnretained(self)
+            .asyncMap { owner, _ in
+                await owner.categoryService.fetchCategoires()
+            }
+            .share()
+        
+        fetchCategories
+            .compactMapValue()
+            .map { response in
+                response.map { PlatformStoreCategory(response: $0) }
+            }
+            .withUnretained(self)
+            .sink { owner, categories in
+                owner.state.categories = categories
+                owner.output.categories.send(categories)
+            }
+            .store(in: &cancellables)
+        
+        fetchCategories
+            .compactMapError()
+            .map { Route.showErrorAlert($0) }
+            .subscribe(output.route)
+            .store(in: &cancellables)
+        
+        let fetchAdvertisement = input.viewDidLoad
+            .withUnretained(self)
+            .asyncMap { owner, _ in
+                let input = FetchAdvertisementInput(position: .menuCategoryBanner, size: nil)
+                
+                return await owner.advertisementService.fetchAdvertisements(input: input)
+            }
+            .share()
+        
+        fetchAdvertisement
+            .compactMapValue()
+            .withUnretained(self)
+            .sink { owner, advertisements in
+                if let advertisementResponse = advertisements.first {
+                    let advertisement = Advertisement(response: advertisementResponse)
+                    
+                    owner.state.advertisement = advertisement
+                    owner.output.advertisement.send(advertisement)
+                } else {
+                    owner.output.advertisement.send(nil)
+                }
+            }
+            .store(in: &cancellables)
+        
+        fetchAdvertisement
+            .compactMapError()
+            .map { _ in nil }
+            .subscribe(output.advertisement)
+            .store(in: &cancellables)
+        
+        input.onTapBanner
+            .withUnretained(self)
+            .compactMap { owner, _ in
+                guard let advertisement = owner.state.advertisement,
+                      let linkUrl = advertisement.linkUrl else { return  nil }
+                
+                return Route.goToWeb(url: linkUrl)
+            }
+            .subscribe(output.route)
+            .store(in: &cancellables)
+        
+        input.onTapCategory
+            .withUnretained(self)
+            .sink { owner, index in
+                guard let selectedCategory = owner.state.categories[safe: index] else { return }
+                
+                if selectedCategory == owner.state.currentCategory {
+                    owner.output.route.send(.dismissWithCategory(nil))
+                } else {
+                    owner.output.route.send(.dismissWithCategory(selectedCategory))
+                }
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/Modules/Feature/Home/Sources/Domains/CategoryFilter/Subview/CategoryBannerCell.swift
+++ b/Modules/Feature/Home/Sources/Domains/CategoryFilter/Subview/CategoryBannerCell.swift
@@ -1,0 +1,81 @@
+import UIKit
+
+import Common
+import DesignSystem
+
+final class CategoryBannerCell: BaseCollectionViewCell {
+    static let size = CGSize(width: UIScreen.main.bounds.width - 48, height: 100)
+    
+    private let containerView = UIView().then {
+        $0.layer.cornerRadius = 12
+    }
+    
+    private let stackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 0
+        $0.alignment = .leading
+    }
+    
+    private let titleLabel = UILabel().then {
+        $0.font = DesignSystemFontFamily.Pretendard.bold.font(size: 14)
+        $0.textAlignment = .left
+    }
+    
+    private let descriptionLabel = UILabel().then {
+        $0.font = DesignSystemFontFamily.Pretendard.regular.font(size: 12)
+        $0.numberOfLines = 0
+    }
+    
+    private let rightImageView = UIImageView()
+    
+    override func setup() {
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(descriptionLabel)
+        addSubViews([
+            containerView,
+            stackView,
+            rightImageView
+        ])
+    }
+    
+    override func bindConstraints() {
+        containerView.snp.makeConstraints {
+            $0.left.equalToSuperview()
+            $0.right.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.height.equalTo(84)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.centerY.equalTo(containerView)
+            $0.left.equalTo(containerView).offset(16)
+            $0.right.equalTo(rightImageView.snp.left)
+        }
+        
+        rightImageView.snp.makeConstraints {
+            $0.top.equalTo(containerView)
+            $0.right.equalTo(containerView)
+            $0.width.height.equalTo(84)
+        }
+    }
+    
+    func bind(advertisement: Advertisement?) {
+        guard let advertisement = advertisement else { return }
+
+        titleLabel.text = advertisement.title
+        titleLabel.textColor = UIColor(hex: advertisement.fontColor ?? "000000")
+        titleLabel.setKern(kern: -0.4)
+        descriptionLabel.text = advertisement.subTitle
+        descriptionLabel.textColor = UIColor(hex: advertisement.fontColor ?? "000000")
+        descriptionLabel.setKern(kern: -0.2)
+        rightImageView.setImage(urlString: advertisement.imageUrl)
+        containerView.backgroundColor = UIColor(hex: advertisement.bgColor ?? "FFFFFF")
+        
+        if let subTitle = advertisement.subTitle,
+           subTitle.count < 21 {
+            stackView.spacing = 0
+        } else {
+            stackView.spacing = 8
+        }
+    }
+}

--- a/Modules/Feature/Home/Sources/Domains/CategoryFilter/Subview/CategoryFilterCell.swift
+++ b/Modules/Feature/Home/Sources/Domains/CategoryFilter/Subview/CategoryFilterCell.swift
@@ -1,0 +1,80 @@
+import UIKit
+
+import Common
+import DesignSystem
+
+final class CategoryFilterCell: BaseCollectionViewCell {
+    static let size = CGSize(
+        width: (UIScreen.main.bounds.width - 48 - 39)/4,
+        height: (UIScreen.main.bounds.width - 48 - 39)/4 + 25
+    )
+    
+    private let newLabel = UILabel().then {
+        $0.text = "new"
+        $0.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 12)
+        $0.textColor = DesignSystemAsset.Colors.systemWhite.color
+        $0.textAlignment = .center
+        $0.backgroundColor = DesignSystemAsset.Colors.mainRed.color
+        $0.layer.masksToBounds = true
+        $0.layer.cornerRadius = 9
+    }
+    
+    private let containerView = UIView().then {
+        $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
+        $0.layer.cornerRadius = 17
+    }
+    
+    private let categoryImage = UIImageView()
+    
+    private let categoryLabel = UILabel().then {
+        // TODO: extraBold 폰트 필요?
+//        $0.font = .extraBold(size: 14)
+        $0.textColor = .black
+        $0.textAlignment = .center
+    }
+    
+    override func setup() {
+        backgroundColor = .clear
+        addSubViews([
+            containerView,
+            newLabel,
+            categoryImage,
+            categoryLabel
+        ])
+    }
+    
+    override func bindConstraints() {
+        newLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.height.equalTo(18)
+            $0.width.equalTo(32)
+        }
+        
+        containerView.snp.makeConstraints {
+            $0.top.equalTo(newLabel).offset(9)
+            $0.left.equalToSuperview()
+            $0.right.equalToSuperview()
+            $0.height.equalTo(Self.size.width)
+        }
+        
+        categoryImage.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(containerView).offset(10)
+            $0.width.equalTo(60)
+            $0.height.equalTo(60)
+        }
+        
+        categoryLabel.snp.makeConstraints {
+            $0.left.equalTo(containerView).offset(10)
+            $0.right.equalTo(containerView).offset(-10)
+            $0.top.equalTo(categoryImage.snp.bottom).offset(4)
+        }
+    }
+    
+    func bind(category: PlatformStoreCategory) {
+        categoryLabel.text = category.name
+        categoryImage.setImage(urlString: category.imageUrl)
+        newLabel.isHidden = category.isNew
+    }
+}

--- a/Modules/Feature/Home/Sources/Domains/CategoryFilter/Subview/CategoryFilterHeaderView.swift
+++ b/Modules/Feature/Home/Sources/Domains/CategoryFilter/Subview/CategoryFilterHeaderView.swift
@@ -1,0 +1,48 @@
+import UIKit
+
+import DesignSystem
+import SnapKit
+import Then
+
+final class CategoryFilterHeaderView: UICollectionReusableView {
+    static let registerId = "\(CategoryFilterHeaderView.self)"
+    static let estimatedHeight: CGFloat = 64
+    
+    private let titleLabel = UILabel().then {
+        $0.textColor = DesignSystemAsset.Colors.systemBlack.color
+        $0.textAlignment = .left
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setup()
+        bindConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setup() {
+        addSubViews([titleLabel])
+    }
+    
+    private func bindConstraints() {
+        titleLabel.snp.makeConstraints {
+            $0.left.equalToSuperview()
+            $0.right.equalToSuperview()
+            $0.top.equalToSuperview().offset(24)
+            $0.bottom.equalToSuperview().offset(-12)
+        }
+    }
+    
+    func bind(title: String, isFirst: Bool) {
+        titleLabel.text = title
+        if isFirst {
+            titleLabel.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 20)
+        } else {
+            titleLabel.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
+        }
+    }
+}

--- a/Modules/Feature/Home/Sources/Domains/Home/HomeView.swift
+++ b/Modules/Feature/Home/Sources/Domains/Home/HomeView.swift
@@ -19,7 +19,7 @@ final class HomeView: BaseView {
         $0.layer.borderWidth = 1
         $0.backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         $0.layer.cornerRadius = 10
-        $0.setTitle("전체 메뉴", for: .normal)
+        $0.setTitle(HomeStrings.homeCategoryFilterButton, for: .normal)
         $0.setTitleColor(DesignSystemAsset.Colors.gray70.color, for: .normal)
         $0.setImage(DesignSystemAsset.Icons.category.image
             .resizeImage(scaledTo: 16)
@@ -34,7 +34,7 @@ final class HomeView: BaseView {
     let onlyBossToggleButton = OnlyBossToggleButton()
     
     let researchButton = UIButton().then {
-        $0.setTitle("현재 지도에서 가게 재검색", for: .normal)
+        $0.setTitle(HomeStrings.homeResearchButton, for: .normal)
         $0.setTitleColor(DesignSystemAsset.Colors.systemWhite.color, for: .normal)
         $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.semiBold.font(size: 12)
         $0.contentEdgeInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
@@ -55,9 +55,9 @@ final class HomeView: BaseView {
         $0.layer.shadowOpacity = 0.1
     }
     
-    let viewTypeButton = UIButton().then {
+    let listViewButton = UIButton().then {
         $0.setImage(DesignSystemAsset.Icons.list.image.resizeImage(scaledTo: 16).withTintColor(DesignSystemAsset.Colors.systemWhite.color), for: .normal)
-        $0.setTitle("리스트뷰", for: .normal)
+        $0.setTitle(HomeStrings.homeListViewButton, for: .normal)
         $0.setTitleColor(DesignSystemAsset.Colors.systemWhite.color, for: .normal)
         $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.medium.font(size: 12)
         $0.layer.cornerRadius = 20
@@ -85,7 +85,7 @@ final class HomeView: BaseView {
             sortingButton,
             onlyBossToggleButton,
             currentLocationButton,
-            viewTypeButton,
+            listViewButton,
             collectionView
         ])
     }
@@ -131,7 +131,7 @@ final class HomeView: BaseView {
             $0.width.height.equalTo(40)
         }
         
-        viewTypeButton.snp.makeConstraints {
+        listViewButton.snp.makeConstraints {
             $0.centerY.equalTo(currentLocationButton)
             $0.right.equalToSuperview().offset(-20)
             $0.height.equalTo(40)

--- a/Modules/Feature/Home/Sources/Domains/Home/HomeViewController.swift
+++ b/Modules/Feature/Home/Sources/Domains/Home/HomeViewController.swift
@@ -5,6 +5,7 @@ import Common
 import DesignSystem
 import NMapsMap
 import Then
+import PanModal
 
 typealias HomeStoreCardSanpshot = NSDiffableDataSourceSnapshot<HomeSection, HomeSectionItem>
 
@@ -172,7 +173,7 @@ public final class HomeViewController: BaseViewController {
             .sink { owner, route in
                 switch route {
                 case .presentCategoryFilter(let category):
-                    print("🔥 카테고리 필터 화면 구현 필요")
+                    owner.presentPanModal(CategoryFilterViewController.instance())
                     
                 case .presentListView:
                     print("🔥 리스트뷰 구현 필요")

--- a/Modules/Feature/Home/Sources/Domains/Home/HomeViewController.swift
+++ b/Modules/Feature/Home/Sources/Domains/Home/HomeViewController.swift
@@ -53,6 +53,12 @@ public final class HomeViewController: BaseViewController {
 //        let searchByAddress = PassthroughSubject<CLLocation, Never>()
 //        let onTapCurrentMarker = PassthroughSubject<Void, Never>()
         
+        homeView.categoryFilterButton
+            .controlPublisher(for: .touchUpInside)
+            .mapVoid
+            .subscribe(viewModel.input.onTapCategoryFilter)
+            .store(in: &cancellables)
+        
         homeView.sortingButton.sortTypePublisher
             .subscribe(viewModel.input.onToggleSort)
             .store(in: &cancellables)
@@ -73,6 +79,12 @@ public final class HomeViewController: BaseViewController {
             .controlPublisher(for: .touchUpInside)
             .mapVoid
             .subscribe(viewModel.input.onTapCurrentLocation)
+            .store(in: &cancellables)
+        
+        homeView.listViewButton
+            .controlPublisher(for: .touchUpInside)
+            .mapVoid
+            .subscribe(viewModel.input.onTapListView)
             .store(in: &cancellables)
         
         homeView.researchButton
@@ -145,6 +157,43 @@ public final class HomeViewController: BaseViewController {
                 owner.homeView.collectionView.scrollToItem(at: indexPath, at: .left, animated: true)
             }
             .store(in: &cancellables)
+        
+        viewModel.output.showLoading
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, isShow in
+                LoadingManager.shared.showLoading(isShow: isShow)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.output.route
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, route in
+                switch route {
+                case .presentCategoryFilter(let category):
+                    print("🔥 카테고리 필터 화면 구현 필요")
+                    
+                case .presentListView:
+                    print("🔥 리스트뷰 구현 필요")
+                    
+                case .pushStoreDetail(let storeId):
+                    print("🔥 상품 상세화면 구현 필요")
+                    
+                case .presentVisit(let storeCard):
+                    print("🔥 방문 화면 구현 필요")
+                    
+                case .presentPolicy:
+                    print("🔥 처리 방침 구현 필요")
+                    
+                case .presentMarkerAdvertisement:
+                    print("🔥 마커 광고 화면 구현 필요")
+                    
+                case .showErrorAlert(let error):
+                    print("🔥 Common 모듈에 AlertUtils 구현 필요")
+                }
+            }
+            .store(in: &cancellables)
     }
     
     private func updateDataSource(section: [HomeSection]) {
@@ -167,11 +216,11 @@ public final class HomeViewController: BaseViewController {
             if selectedIndex == value.offset {
                 marker.width = 32
                 marker.height = 40
-                marker.iconImage = NMFOverlayImage(image: ImageProvider.image(name: "icon_marker_focused"))
+                marker.iconImage = NMFOverlayImage(image: HomeAsset.iconMarkerFocused.image)
             } else {
                 marker.width = 24
                 marker.height = 24
-                marker.iconImage = NMFOverlayImage(image: ImageProvider.image(name: "icon_marker_unfocused"))
+                marker.iconImage = NMFOverlayImage(image: HomeAsset.iconMarkerUnfocused.image)
             }
             guard let latitude = value.element.location?.latitude,
                   let longitude = value.element.location?.longitude else { break }

--- a/Modules/Feature/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -11,12 +11,14 @@ final class HomeViewModel: BaseViewModel {
         let onMapLoad = PassthroughSubject<Double, Never>()
         let changeMaxDistance = PassthroughSubject<Double, Never>()
         let changeMapLocation = PassthroughSubject<CLLocation, Never>()
+        let onTapCategoryFilter = PassthroughSubject<Void, Never>()
         let selectCategory = PassthroughSubject<Category?, Never>()
         let onToggleSort = PassthroughSubject<StoreSortType, Never>()
         let onTapOnlyBoss = PassthroughSubject<Void, Never>()
         let searchByAddress = PassthroughSubject<CLLocation, Never>()
         let onTapResearch = PassthroughSubject<Void, Never>()
         let onTapCurrentLocation = PassthroughSubject<Void, Never>()
+        let onTapListView = PassthroughSubject<Void, Never>()
         let selectStore = PassthroughSubject<Int, Never>()
         let onTapStore = PassthroughSubject<Int, Never>()
         let onTapVisitButton = PassthroughSubject<Int, Never>()
@@ -52,7 +54,7 @@ final class HomeViewModel: BaseViewModel {
     }
     
     enum Route {
-        case presentCategoryFilter
+        case presentCategoryFilter(Category?)
         case presentListView
         case pushStoreDetail(storeId: String)
         case presentVisit(StoreCard)
@@ -177,6 +179,14 @@ final class HomeViewModel: BaseViewModel {
             }
             .store(in: &cancellables)
         
+        input.onTapCategoryFilter
+            .withUnretained(self)
+            .map { owner, _ in
+                Route.presentCategoryFilter(owner.state.categoryFilter)
+            }
+            .subscribe(output.route)
+            .store(in: &cancellables)
+        
         input.selectCategory
             .withUnretained(self)
             .handleEvents(receiveOutput: { owner, categoryFilter in
@@ -289,6 +299,13 @@ final class HomeViewModel: BaseViewModel {
                 owner.state.currentLocation = location
                 owner.output.cameraPosition.send(location)
             }
+            .store(in: &cancellables)
+        
+        input.onTapListView
+            .map { _ in
+                Route.presentListView
+            }
+            .subscribe(output.route)
             .store(in: &cancellables)
         
         input.selectStore

--- a/Modules/Feature/Home/Sources/Domains/Home/Subview/HomeStoreCardCell.swift
+++ b/Modules/Feature/Home/Sources/Domains/Home/Subview/HomeStoreCardCell.swift
@@ -39,7 +39,7 @@ final class HomeStoreCardCell: BaseCollectionViewCell {
         $0.setImage(DesignSystemAsset.Icons.locationSolid.image
             .resizeImage(scaledTo: 16)
             .withTintColor(DesignSystemAsset.Colors.systemWhite.color), for: .normal)
-        $0.setTitle("방문하기", for: .normal)
+        $0.setTitle(HomeStrings.homeVisitButton, for: .normal)
         $0.setTitleColor(DesignSystemAsset.Colors.systemWhite.color, for: .normal)
         $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
         $0.contentEdgeInsets = .init(top: 10, left: 10, bottom: 10, right: 14)

--- a/Modules/Feature/Home/Sources/Domains/Home/Subview/HomeStoreEmptyCell.swift
+++ b/Modules/Feature/Home/Sources/Domains/Home/Subview/HomeStoreEmptyCell.swift
@@ -13,14 +13,14 @@ final class HomeStoreEmptyCell: BaseCollectionViewCell {
         $0.backgroundColor = DesignSystemAsset.Colors.gray100.color
     }
     
-    private let categoryImage = UIImageView(image: ImageProvider.image(name: "image_empty_category"))
+    private let categoryImage = UIImageView(image: HomeAsset.imageEmptyCategory.image)
     
     private let titleLabel = UILabel().then {
         $0.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
         $0.textColor = DesignSystemAsset.Colors.systemWhite.color
         $0.numberOfLines = 2
         $0.textAlignment = .left
-        $0.text = "주변 2km 이내에\n가게가 없어요."
+        $0.text = HomeStrings.homeEmptyTitle
     }
     
     private let descriptionLabel = UILabel().then {
@@ -28,7 +28,7 @@ final class HomeStoreEmptyCell: BaseCollectionViewCell {
         $0.textColor = DesignSystemAsset.Colors.gray50.color
         $0.numberOfLines = 1
         $0.textAlignment = .left
-        $0.text = "다른 주소로 검색하거나 직접 제보해보세요!"
+        $0.text = HomeStrings.homeEmptyDescription
     }
     
     override func setup() {

--- a/Modules/Feature/Home/Sources/Domains/Home/Subview/OnlyBossToggleButton.swift
+++ b/Modules/Feature/Home/Sources/Domains/Home/Subview/OnlyBossToggleButton.swift
@@ -27,7 +27,7 @@ public final class OnlyBossToggleButton: UIButton {
         layer.borderWidth = 1
         backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         layer.cornerRadius = 10
-        setTitle("사장님 직영점만", for: .normal)
+        setTitle(HomeStrings.homeOnlyBossButton, for: .normal)
         setTitleColor(DesignSystemAsset.Colors.gray40.color, for: .normal)
         setTitleColor(DesignSystemAsset.Colors.gray70.color, for: .selected)
         setImage(DesignSystemAsset.Icons.check.image

--- a/Modules/Feature/Home/Sources/Domains/Home/Subview/SortingButton.swift
+++ b/Modules/Feature/Home/Sources/Domains/Home/Subview/SortingButton.swift
@@ -24,7 +24,7 @@ final class SortingButton: UIButton {
         layer.borderWidth = 1
         backgroundColor = DesignSystemAsset.Colors.systemWhite.color
         layer.cornerRadius = 10
-        setTitle("거리순 보기", for: .normal)
+        setTitle(HomeStrings.homeSortingButtonDistance, for: .normal)
         setTitleColor(DesignSystemAsset.Colors.gray70.color, for: .normal)
         setImage(DesignSystemAsset.Icons.change.image
             .resizeImage(scaledTo: 16)
@@ -50,9 +50,9 @@ final class SortingButton: UIButton {
     private func bind(_ sortType: StoreSortType) {
         switch sortType {
         case .distanceAsc:
-            setTitle("거리순 보기", for: .normal)
+            setTitle(HomeStrings.homeSortingButtonDistance, for: .normal)
         case .latest:
-            setTitle("최근 등록순 보기", for: .normal)
+            setTitle(HomeStrings.homeSortingButtonLatest, for: .normal)
         case .unknown:
             break
         }

--- a/Modules/Feature/Home/Sources/ImageProvider.swift
+++ b/Modules/Feature/Home/Sources/ImageProvider.swift
@@ -1,7 +1,0 @@
-import UIKit
-
-class ImageProvider {
-    static func image(name: String) -> UIImage {
-        return UIImage(named: name, in: Bundle(for: self), with: nil) ?? UIImage()
-    }
-}

--- a/Modules/Feature/Home/Sources/Model/Advertisement.swift
+++ b/Modules/Feature/Home/Sources/Model/Advertisement.swift
@@ -27,3 +27,9 @@ struct Advertisement {
         self.fontColor = response.fontColor
     }
 }
+
+extension Advertisement: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(advertisementId)
+    }
+}

--- a/Modules/Feature/Home/Sources/Model/CategorySection.swift
+++ b/Modules/Feature/Home/Sources/Model/CategorySection.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct CategorySection: Hashable {
+    var title: String
+    var items: [CategorySectionItem]
+}
+
+enum CategorySectionItem: Hashable {
+    case category(PlatformStoreCategory)
+    case advertisement(Advertisement?)
+}

--- a/Modules/Feature/Home/Sources/Model/PlatformStoreCategory.swift
+++ b/Modules/Feature/Home/Sources/Model/PlatformStoreCategory.swift
@@ -24,3 +24,9 @@ struct PlatformStoreCategory {
         self.isNew = response.isNew
     }
 }
+
+extension PlatformStoreCategory: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(categoryId)
+    }
+}

--- a/Modules/Network/Sources/APIs/Request/FetchAdvertisementRequest.swift
+++ b/Modules/Network/Sources/APIs/Request/FetchAdvertisementRequest.swift
@@ -16,6 +16,6 @@ struct FetchAdvertisementRequest: RequestType {
     }
     
     var path: String {
-        return "/v1/advertisements"
+        return "/api/v1/advertisements"
     }
 }

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -6,6 +6,7 @@ let dependencies = Dependencies(
         .remote(url: "https://github.com/SnapKit/SnapKit", requirement: .upToNextMajor(from: "5.0.0")),
         .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .exact("7.6.2")),
         .remote(url: "https://github.com/airbnb/lottie-ios.git", requirement: .exact("4.0.1")),
+        .remote(url: "https://github.com/slackhq/PanModal.git", requirement: .exact("1.2.6"))
     ],
     platforms: [.iOS]
 )


### PR DESCRIPTION
### 모듈별 변경사항
- 홈 모듈
    - 카테고리 필터 화면 구현 (디자인이 아직 모두 구현되지 않아 비슷하게 먼저 구현했습니다.)
    - 필터 화면 구현을 위해 [PanModal](https://github.com/slackhq/PanModal) 라이브러리 추가
- Common 모듈 (여러 모듈에서 공통으로 사용하는 익스텐션 추가했습니다.)
    - UIColorExtension
    - UICollectionViewDiffableDataSourceExtension
    - UILabelExtension
-  Networking모듈
    - advertisement API endPoint 주소 수정 (에러사항)

### 테스트
- 홈 화면 데모앱을 통해 확인 가능합니다.
- 카테고리 필터 화면 선택

<video src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/assets/7058293/7bbbb6e3-32a0-49df-b4b5-41577ed039f3" width=360>



