### PR TITLE
위치 권한 없이 실행 시, 로딩화면 사라지지 않는 버그 수정

### DIFF
--- a/Modules/Feature/Home/Derived/Sources/TuistStrings+Home.swift
+++ b/Modules/Feature/Home/Derived/Sources/TuistStrings+Home.swift
@@ -40,6 +40,10 @@ public enum HomeStrings {
   public static let homeSortingButtonLatest = HomeStrings.tr("Localization", "home_sorting_button_latest")
   /// 방문하기
   public static let homeVisitButton = HomeStrings.tr("Localization", "home_visit_button")
+  /// 현재 내 위치와 가까운 가게를 찾기 위해 위치 권한이 필요합니다. 설정에서 위치 권한을 허용시켜주세요.
+  public static let locationDenyDescription = HomeStrings.tr("Localization", "location_deny_description")
+  /// 위치 권한 거절
+  public static let locationDenyTitle = HomeStrings.tr("Localization", "location_deny_title")
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name

--- a/Modules/Feature/Home/Targets/Home/Resources/en.lproj/Localization.strings
+++ b/Modules/Feature/Home/Targets/Home/Resources/en.lproj/Localization.strings
@@ -18,3 +18,6 @@
 // 홈 리스트 뷰 화면
 "home_list_header_total" = "전체 메뉴";
 "home_list_is_only_certified" = "방문 인증 가게";
+
+"location_deny_title" = "위치 권한 거절";
+"location_deny_description" = "현재 내 위치와 가까운 가게를 찾기 위해 위치 권한이 필요합니다. 설정에서 위치 권한을 허용시켜주세요.";

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewController.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewController.swift
@@ -201,7 +201,11 @@ public final class HomeViewController: BaseViewController {
                     print("🔥 마커 광고 화면 구현 필요")
                     
                 case .showErrorAlert(let error):
-                    owner.showErrorAlert(error: error)
+                    if error is LocationError {
+                        owner.showDenyAlert()
+                    } else {
+                        owner.showErrorAlert(error: error)
+                    }
                 }
             }
             .store(in: &cancellables)
@@ -252,6 +256,26 @@ public final class HomeViewController: BaseViewController {
             marker.mapView = nil
         }
         self.markers.removeAll()
+    }
+    
+    private func showDenyAlert() {
+        AlertUtils.showWithAction(
+            viewController: self,
+            title: HomeStrings.locationDenyTitle,
+            message: HomeStrings.locationDenyDescription
+        ) { [weak self] in
+            self?.goToAppSetting()
+        }
+    }
+    
+    private func goToAppSetting() {
+        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        
+        if UIApplication.shared.canOpenURL(settingsUrl) {
+            UIApplication.shared.open(settingsUrl, options: [:], completionHandler: nil)
+        }
     }
 }
 

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -102,6 +102,7 @@ final class HomeViewModel: BaseViewModel {
             .flatMap { owner, _  in
                 owner.locationManager.getCurrentLocationPublisher()
                     .catch { error -> AnyPublisher<CLLocation, Never> in
+                        owner.output.showLoading.send(false)
                         owner.output.route.send(.showErrorAlert(error))
                         return Empty().eraseToAnyPublisher()
                     }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -7,6 +7,10 @@ import Model
 import Common
 
 final class HomeViewModel: BaseViewModel {
+    enum Constent {
+        static let defaultLocation = CLLocation(latitude: 37.497941, longitude: 127.027616)
+    }
+    
     struct Input {
         let viewDidLoad = PassthroughSubject<Void, Never>()
         let onMapLoad = PassthroughSubject<Double, Never>()
@@ -104,7 +108,8 @@ final class HomeViewModel: BaseViewModel {
                     .catch { error -> AnyPublisher<CLLocation, Never> in
                         owner.output.showLoading.send(false)
                         owner.output.route.send(.showErrorAlert(error))
-                        return Empty().eraseToAnyPublisher()
+                        
+                        return Just(Constent.defaultLocation).eraseToAnyPublisher()
                     }
             }
             .share()
@@ -286,6 +291,30 @@ final class HomeViewModel: BaseViewModel {
                     owner.output.route.send(.showErrorAlert(error))
                 }
             })
+            .store(in: &cancellables)
+        
+        input.onTapResearch
+            .withUnretained(self)
+            .asyncMap { owner, _ in
+                let latitude = owner.state.newCameraPosition?.coordinate.latitude ?? Constent.defaultLocation.coordinate.latitude
+                let longitude = owner.state.newCameraPosition?.coordinate.longitude ?? Constent.defaultLocation.coordinate.longitude
+                
+                return await owner.mapService.getAddressFromLocation(
+                    latitude: latitude,
+                    longitude: longitude
+                )
+            }
+            .withUnretained(self)
+            .sink { owner, result in
+                switch result {
+                case .success(let address):
+                    owner.state.address = address
+                    owner.output.address.send(address)
+                    
+                case .failure(let error):
+                    owner.output.route.send(.showErrorAlert(error))
+                }
+            }
             .store(in: &cancellables)
             
         


### PR DESCRIPTION
### 버그 내용
- 로그인/회원가입 이후 위치권한 팝업에서 거절했을 경우, 로딩화면이 사라지지 않는 오류 수정
- 권한 없이 진입 했을 때, 강남역을 기본 검색 위치로 설정
- 관련 이슈: #113 