### PR TITLE
커뮤니티탭 버그 수정 및 개선

### DIFF
--- a/Modules/Common/Targets/Common/Sources/Extension/UIScrollViewExtension.swift
+++ b/Modules/Common/Targets/Common/Sources/Extension/UIScrollViewExtension.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+public extension UIScrollView {
+    func scrollToTop(animated: Bool = true) {
+        let targetContentOffset = CGPoint(
+            x: -contentInset.left,
+            y: -contentInset.top
+        )
+        setContentOffset(targetContentOffset, animated: animated)
+    }
+}

--- a/Modules/Common/Targets/Model/Sources/Domain/Input/FetchPollsRequestInput.swift
+++ b/Modules/Common/Targets/Model/Sources/Domain/Input/FetchPollsRequestInput.swift
@@ -6,9 +6,9 @@ public struct FetchPollsRequestInput: Encodable {
     public let size: Int
     public let cursor: String?
 
-    public init(categoryId: String = "TASTE_VS_TASTE", sortType: String = "LATEST", size: Int = 20, cursor: String? = nil) {
+    public init(categoryId: String = "TASTE_VS_TASTE", sortType: PollListSortType = .latest, size: Int = 20, cursor: String? = nil) {
         self.categoryId = categoryId
-        self.sortType = sortType
+        self.sortType = sortType.rawValue
         self.size = size
         self.cursor = cursor
     }

--- a/Modules/Common/Targets/Model/Sources/Domain/Response/PollCommentApiResponse.swift
+++ b/Modules/Common/Targets/Model/Sources/Domain/Response/PollCommentApiResponse.swift
@@ -17,6 +17,7 @@ public struct PollCommentApiResponse: Decodable {
     public let status: PollCommentStatus
     public let createdAt: String
     public let updatedAt: String
+    public let isOwner: Bool
 
     public enum PollCommentStatus: String, Decodable {
         case active = "ACTIVE"

--- a/Modules/Common/Targets/Model/Sources/Domain/Response/PollPolicyApiResponse.swift
+++ b/Modules/Common/Targets/Model/Sources/Domain/Response/PollPolicyApiResponse.swift
@@ -7,4 +7,5 @@ public struct PollPolicyApiResponse: Decodable {
 public struct PollCreatePolicyApiResponse: Decodable {
     public let limitCount: Int
     public let currentCount: Int
+    public let pollRetentionDays: Int
 }

--- a/Modules/Common/Targets/Model/Sources/Presentation/PollListSortType.swift
+++ b/Modules/Common/Targets/Model/Sources/Presentation/PollListSortType.swift
@@ -1,0 +1,9 @@
+public enum PollListSortType: String {
+    case latest = "LATEST"
+    case popular = "POPULAR"
+    case unknown
+
+    public init(value: String) {
+        self = PollListSortType(rawValue: value) ?? .unknown
+    }
+}

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/CommunityDataSource.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/CommunityDataSource.swift
@@ -75,7 +75,7 @@ final class CommunityDataSource: UICollectionViewDiffableDataSource<CommunitySec
             snapshot.appendItems($0.items)
         }
 
-        apply(snapshot, animatingDifferences: true)
+        apply(snapshot, animatingDifferences: false)
     }
 }
 

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/CategoryTab/PollCategoryTabViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/CategoryTab/PollCategoryTabViewModel.swift
@@ -21,7 +21,7 @@ final class PollCategoryTabViewModel: BaseViewModel {
     }
 
     struct State {
-
+        var createPolicy: PollCreatePolicyApiResponse?
     }
 
     enum Route {
@@ -61,6 +61,7 @@ final class PollCategoryTabViewModel: BaseViewModel {
                 switch result {
                 case .success(let response):
                     owner.updateCreatePollButton(with: response)
+                    owner.state.createPolicy = response.createPolicy
                 case .failure(let error):
                     owner.output.showToast.send("유저 투표 정책 조회 실패: \(error.localizedDescription)")
                 }
@@ -98,7 +99,7 @@ final class PollCategoryTabViewModel: BaseViewModel {
     }
 
     private func bindCreatePollModalViewModel() -> CreatePollModalViewModel {
-        let viewModel = CreatePollModalViewModel()
+        let viewModel = CreatePollModalViewModel(pollRetentionDays: state.createPolicy?.pollRetentionDays ?? 3)
 
         viewModel.output.created
             .subscribe(input.updatePollList)

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/CategoryTab/PollListViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/CategoryTab/PollListViewModel.swift
@@ -32,13 +32,13 @@ final class PollListViewModel: BaseViewModel {
 
     let input = Input()
     let output = Output()
-    let sortType: String
+    let sortType: PollListSortType
 
     private var state = State()
     private let communityService: CommunityServiceProtocol
 
     init(
-        sortType: String = "LATEST", // TODO
+        sortType: PollListSortType = .latest, // 현재 따로 변경하고 있지는 않음
         communityService: CommunityServiceProtocol = CommunityService()
     ) {
         self.sortType = sortType

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Create/CreatePollModalViewController.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Create/CreatePollModalViewController.swift
@@ -80,7 +80,7 @@ final class CreatePollModalViewController: BaseViewController {
         $0.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
     }
 
-    private let descriptionLabel = UILabel().then {
+    private lazy var descriptionLabel = UILabel().then {
         $0.font = Fonts.medium.font(size: 12)
         $0.textColor = Colors.gray50.color
         $0.numberOfLines = 0
@@ -90,12 +90,12 @@ final class CreatePollModalViewController: BaseViewController {
         style.maximumLineHeight = 18
         style.minimumLineHeight = 18
 
-        let text = "* 투표는 3일 동안만 진행돼요\n* 1일 1회만 올릴 수 있어요\n* 부적절한 내용일 경우 임의로 삭제될 수 있어요"
+        let text = "* 투표는 \(viewModel.output.pollRetentionDays)일 동안만 진행돼요\n* 1일 1회만 올릴 수 있어요\n* 부적절한 내용일 경우 임의로 삭제될 수 있어요"
         let attributedText = NSMutableAttributedString(string: text, attributes: [.paragraphStyle: style])
         attributedText.addAttribute(
             .foregroundColor,
             value: Colors.gray100.color,
-            range: (text as NSString).range(of: "3일 동안")
+            range: (text as NSString).range(of: "\(viewModel.output.pollRetentionDays)일 동안")
         )
         attributedText.addAttribute(
             .foregroundColor,

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Create/CreatePollModalViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Create/CreatePollModalViewModel.swift
@@ -15,6 +15,7 @@ final class CreatePollModalViewModel: BaseViewModel {
     }
 
     struct Output {
+        let pollRetentionDays: Int
         let showLoading = PassthroughSubject<Bool, Never>()
         let showToast = PassthroughSubject<String, Never>()
         let route = PassthroughSubject<Route, Never>()
@@ -31,14 +32,16 @@ final class CreatePollModalViewModel: BaseViewModel {
     }
 
     let input = Input()
-    let output = Output()
+    let output: Output
 
     private var state = State()
     private let communityService: CommunityServiceProtocol
 
     init(
+        pollRetentionDays: Int,
         communityService: CommunityServiceProtocol = CommunityService()
     ) {
+        self.output = Output(pollRetentionDays: pollRetentionDays)
         self.communityService = communityService
 
         super.init()

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/Cell/PollDetailCommentCell.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/Cell/PollDetailCommentCell.swift
@@ -13,6 +13,8 @@ final class PollDetailCommentCell: BaseCollectionViewCell {
         }
     }
 
+    weak var containerVC: UIViewController?
+
     private let userNameLabel = UILabel().then {
         $0.font = Fonts.medium.font(size: 12)
         $0.textColor = Colors.gray80.color
@@ -141,6 +143,12 @@ final class PollDetailCommentCell: BaseCollectionViewCell {
             .main
             .sink { ToastManager.shared.show(message: $0) }
             .store(in: &cancellables)
+
+        viewModel.output.showDeleteAlert
+            .main
+            .withUnretained(self)
+            .sink { owner, _ in owner.showDeleteAlert() }
+            .store(in: &cancellables)
     }
 
     private func bindUI(with data: PollCommentWithUserApiResponse, isMine: Bool) {
@@ -170,6 +178,26 @@ final class PollDetailCommentCell: BaseCollectionViewCell {
             title: data.commentWriter.medal.name
         )
         medalView.setBackgroundColor(isMine ? Colors.systemWhite.color : nil)
+    }
+
+    private func showDeleteAlert() {
+        guard let containerVC else { return }
+
+        let okAction = UIAlertAction(
+            title: "삭제",
+            style: .default
+        ) { [weak self] _ in
+            self?.viewModel?.input.deleteAction.send()
+        }
+
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+
+        AlertUtils.show(
+            viewController: containerVC,
+            title: "삭제하시겠습니까?",
+            message: "",
+            [okAction, cancelAction]
+        )
     }
 }
 

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/Cell/PollDetailCommentCellViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/Cell/PollDetailCommentCellViewModel.swift
@@ -32,21 +32,18 @@ final class PollDetailCommentCellViewModel: BaseViewModel {
 
     private let pollId: String
     private let commentId: String
-    private let userInfo: UserWithDeviceApiResponse?
 
     init(
         pollId: String,
         data: PollCommentWithUserApiResponse,
-        userInfo: UserWithDeviceApiResponse?,
         communityService: CommunityServiceProtocol = CommunityService()
     ) {
         self.pollId = pollId
         self.commentId = data.comment.commentId
         self.communityService = communityService
-        self.userInfo = userInfo
         self.output = Output(
             item: data,
-            isMine: userInfo?.userId == data.commentWriter.userId
+            isMine: data.comment.isOwner
         )
 
         super.init()

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/PollDetailDataSource.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/PollDetailDataSource.swift
@@ -61,7 +61,7 @@ final class PollDetailDataSource: UICollectionViewDiffableDataSource<PollDetailS
 
     private typealias Snapshot = NSDiffableDataSourceSnapshot<PollDetailSection, PollDetailSectionItem>
 
-    init(collectionView: UICollectionView) {
+    init(collectionView: UICollectionView, containerVC: UIViewController) {
         collectionView.register([
             PollDetailContentCell.self,
             PollDetailCommentCell.self,
@@ -72,7 +72,7 @@ final class PollDetailDataSource: UICollectionViewDiffableDataSource<PollDetailS
             PollDetailCommentHeaderView.self,
         ])
 
-        super.init(collectionView: collectionView) {collectionView, indexPath, itemIdentifier in
+        super.init(collectionView: collectionView) { [weak containerVC] collectionView, indexPath, itemIdentifier in
             switch itemIdentifier {
             case .detail(let cellViewModel):
                 let cell: PollDetailContentCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
@@ -81,6 +81,7 @@ final class PollDetailDataSource: UICollectionViewDiffableDataSource<PollDetailS
             case .comment(let cellViewModel):
                 let cell: PollDetailCommentCell = collectionView.dequeueReuseableCell(indexPath: indexPath)
                 cell.bind(viewModel: cellViewModel)
+                cell.containerVC = containerVC
                 return cell
             case .blindComment:
                 let cell: PollDetailBlindCommentCell = collectionView.dequeueReuseableCell(indexPath: indexPath)

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/PollDetailViewController.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/PollDetailViewController.swift
@@ -24,7 +24,7 @@ final class PollDetailViewController: BaseViewController {
 
     private let writeCommentView = PollDetailWriteCommentView()
 
-    private lazy var dataSource = PollDetailDataSource(collectionView: collectionView)
+    private lazy var dataSource = PollDetailDataSource(collectionView: collectionView, containerVC: self)
 
     private let viewModel: PollDetailViewModel
 

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/PollDetailViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/PollDetailViewModel.swift
@@ -174,8 +174,8 @@ final class PollDetailViewModel: BaseViewModel {
                 switch result {
                 case .success(let response):
                     let comments = [response.current] + owner.state.comments.value
-                    owner.state.comments.send(comments)
                     owner.state.commentTotalCount += 1
+                    owner.state.comments.send(comments)
                     owner.output.completedWriteComment.send()
                 case .failure(let error):
                     owner.output.showToast.send("실패: \(error.localizedDescription)")

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/PollDetailViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/PollDetailViewModel.swift
@@ -25,7 +25,6 @@ final class PollDetailViewModel: BaseViewModel {
         let showToast = PassthroughSubject<String, Never>()
         let route = PassthroughSubject<Route, Never>()
         let completedWriteComment = PassthroughSubject<Void, Never>()
-        let userInfo = CurrentValueSubject<UserWithDeviceApiResponse?, Never>(nil)
     }
 
     struct State {
@@ -47,33 +46,21 @@ final class PollDetailViewModel: BaseViewModel {
 
     private var state = State()
     private let communityService: CommunityServiceProtocol
-    private let userService: UserServiceProtocol
 
     private let pollId: String
 
     init(
         pollId: String,
-        communityService: CommunityServiceProtocol = CommunityService(),
-        userService: UserServiceProtocol = UserService()
+        communityService: CommunityServiceProtocol = CommunityService()
     ) {
         self.pollId = pollId
         self.communityService = communityService
-        self.userService = userService
 
         super.init()
     }
 
     override func bind() {
         super.bind()
-
-        input.firstLoad
-            .withUnretained(self)
-            .asyncMap { owner, _ in
-                await owner.userService.fetchUser()
-            }
-            .mapValue()
-            .subscribe(output.userInfo)
-            .store(in: &cancellables)
 
         input.firstLoad
             .withUnretained(self)
@@ -247,8 +234,7 @@ final class PollDetailViewModel: BaseViewModel {
     private func bindCommentCellViewModel(with data: PollCommentWithUserApiResponse) -> PollDetailCommentCellViewModel {
         let cellViewModel = PollDetailCommentCellViewModel(
             pollId: pollId,
-            data: data,
-            userInfo: output.userInfo.value
+            data: data
         )
 
         cellViewModel.output.deleteCell

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Report/ReportPollViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Report/ReportPollViewModel.swift
@@ -19,6 +19,7 @@ final class ReportPollViewModel: BaseViewModel {
         let isEnabledButton = PassthroughSubject<Bool, Never>()
         let route = PassthroughSubject<Route, Never>()
         let showToast = PassthroughSubject<String, Never>()
+        let reportComment = PassthroughSubject<String, Never>()
     }
 
     struct State {
@@ -151,7 +152,11 @@ final class ReportPollViewModel: BaseViewModel {
             }
             .withUnretained(self)
             .asyncMap { owner, input in
-                await owner.communityService.reportComment(pollId: owner.pollId, commentId: owner.commentId ?? "", input: input)
+                await owner.communityService.reportComment(
+                    pollId: owner.pollId,
+                    commentId: owner.commentId ?? "",
+                    input: input
+                )
             }
             .withUnretained(self)
             .sink { owner, result in
@@ -159,6 +164,9 @@ final class ReportPollViewModel: BaseViewModel {
                 switch result {
                 case .success(let response):
                     owner.output.showToast.send("신고했어요")
+                    if let commentId = owner.commentId {
+                        owner.output.reportComment.send(commentId)
+                    }
                     owner.output.route.send(.back)
                 case .failure(let error):
                     owner.output.showToast.send("실패: \(error.localizedDescription)")

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/PopularStore/CommunityPopularStoreItemCell.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/PopularStore/CommunityPopularStoreItemCell.swift
@@ -8,7 +8,7 @@ import Model
 final class CommunityPopularStoreItemCell: BaseCollectionViewCell {
 
     enum Layout {
-        static let size = CGSize(width: UIScreen.main.bounds.width - 40, height: 72)
+        static let size = CGSize(width: UIScreen.main.bounds.width, height: 72)
     }
 
     private let containerView = UIView().then {
@@ -64,7 +64,8 @@ final class CommunityPopularStoreItemCell: BaseCollectionViewCell {
         super.bindConstraints()
 
         containerView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(20)
         }
 
         imageView.snp.makeConstraints {

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Subviews/CommunityPollListCell.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Subviews/CommunityPollListCell.swift
@@ -106,8 +106,17 @@ final class CommunityPollListCell: BaseCollectionViewCell {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.collectionView.reloadData()
+                owner.scrollToStoredContentOffset()
             }
             .store(in: &cancellables)
+    }
+
+    private func scrollToStoredContentOffset() {
+        if let contentOffset = viewModel?.output.storedContentOffset.value {
+            collectionView.contentOffset = contentOffset
+        } else {
+            collectionView.scrollToTop(animated: false)
+        }
     }
 }
 
@@ -128,5 +137,10 @@ extension CommunityPollListCell: UICollectionViewDataSource {
 extension CommunityPollListCell: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         viewModel?.input.didSelectPollItem.send(indexPath.item)
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let contentOffset = collectionView.contentOffset
+        viewModel?.input.updateStoredContentOffset.send(contentOffset)
     }
 }

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Subviews/CommunityPollListCellViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Subviews/CommunityPollListCellViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 
 import Common
 import Model
@@ -9,12 +10,14 @@ final class CommunityPollListCellViewModel: BaseViewModel {
         let didSelectPollItem = PassthroughSubject<Int, Never>()
         let didSelectCategory = PassthroughSubject<Void, Never>()
         let reload = PassthroughSubject<Void, Never>()
+        let updateStoredContentOffset = PassthroughSubject<CGPoint?, Never>()
     }
 
     struct Output {
         let pollList = CurrentValueSubject<[PollItemCellViewModel], Never>([])
         let didSelectPollItem = PassthroughSubject<String, Never>()
         let didSelectCategory = PassthroughSubject<String, Never>()
+        let storedContentOffset = CurrentValueSubject<CGPoint?, Never>(nil)
     }
 
     struct State {
@@ -61,6 +64,10 @@ final class CommunityPollListCellViewModel: BaseViewModel {
             .sink { owner, _ in
                 owner.fetchPolls()
             }
+            .store(in: &cancellables)
+
+        input.updateStoredContentOffset
+            .subscribe(output.storedContentOffset)
             .store(in: &cancellables)
     }
 

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Subviews/CommunityPollListCellViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Subviews/CommunityPollListCellViewModel.swift
@@ -68,7 +68,7 @@ final class CommunityPollListCellViewModel: BaseViewModel {
         Task { [weak self] in
             guard let self else { return }
 
-            let input = FetchPollsRequestInput()
+            let input = FetchPollsRequestInput(sortType: .popular)
 
             let result = await communityService.fetchPolls(input: input)
 

--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Subviews/CommunityPollListCellViewModel.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Subviews/CommunityPollListCellViewModel.swift
@@ -75,9 +75,7 @@ final class CommunityPollListCellViewModel: BaseViewModel {
         Task { [weak self] in
             guard let self else { return }
 
-            let input = FetchPollsRequestInput(sortType: .popular)
-
-            let result = await communityService.fetchPolls(input: input)
+            let result = await communityService.fetchPolls(input: FetchPollsRequestInput(sortType: .popular))
 
             switch result {
             case .success(let response):


### PR DESCRIPTION
- [x] 커뮤니티 메인 탭에서 투표 조회 시, sortType = LATEST -> POPULAR 로 변경
- [x] 내가 작성한 코멘트는 isOwner 필드로 판단 (GET /user/me API 호출 제거)
- [x] 투표 댓글 삭제 버튼 클릭 시에 얼럿 노출
- [x] #131 
- [x] #132
- [x] 인기 가게 동네 변경하면 투표 스크롤 위치 변경 
- [x] 투표 만들기 정책 값 서버에서 받아오도록 수정