### PR TITLE
TH-99 : 파이어베이스 푸시 (마케팅/푸시 알림 설정 필터링 적용)

### DIFF
--- a/App/Targets/AppInterface/Sources/AppModuleInterface.swift
+++ b/App/Targets/AppInterface/Sources/AppModuleInterface.swift
@@ -18,6 +18,8 @@ public protocol AppModuleInterface {
     func createWebViewController(webviewType: WebViewType) -> UIViewController
     func shareKakao(storeId: Int, storeType: StoreType, storeDetailOverview: StoreDetailOverview)
     func requestATTIfNeeded()
+    func subscribeMarketingFCMTopic(completion: @escaping ((Error?) -> Void))
+    func unsubscribeMarketingFCMTopic(completion: @escaping ((Error?) -> Void))
     
     /// GA
     func sendPageView(screenName: String, type: AnyObject.Type)

--- a/App/Targets/three-dollar-in-my-pocket/Sources/DI/AppModuleInterfaceImpl.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/DI/AppModuleInterfaceImpl.swift
@@ -155,6 +155,14 @@ final class AppModuleInterfaceImpl: AppModuleInterface {
     func sendEvent(name: String, parameters: [String : Any]?) {
         Analytics.logEvent(name, parameters: parameters)
     }
+    
+    func subscribeMarketingFCMTopic(completion: @escaping ((Error?) -> Void)) {
+        Messaging.messaging().subscribe(toTopic: "Marketing", completion: completion)
+    }
+    
+    func unsubscribeMarketingFCMTopic(completion: @escaping ((Error?) -> Void)) {
+        Messaging.messaging().unsubscribe(fromTopic: "Marketing", completion: completion)
+    }
 }
 
 extension AppModuleInterfaceImpl {

--- a/App/Targets/three-dollar-in-my-pocket/Sources/DI/AppModuleInterfaceImpl.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/DI/AppModuleInterfaceImpl.swift
@@ -157,11 +157,11 @@ final class AppModuleInterfaceImpl: AppModuleInterface {
     }
     
     func subscribeMarketingFCMTopic(completion: @escaping ((Error?) -> Void)) {
-        Messaging.messaging().subscribe(toTopic: "Marketing", completion: completion)
+        Messaging.messaging().subscribe(toTopic: "marketing_ios", completion: completion)
     }
     
     func unsubscribeMarketingFCMTopic(completion: @escaping ((Error?) -> Void)) {
-        Messaging.messaging().unsubscribe(fromTopic: "Marketing", completion: completion)
+        Messaging.messaging().unsubscribe(fromTopic: "marketing_ios", completion: completion)
     }
 }
 

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/my-page/setting/SettingReactor.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/my-page/setting/SettingReactor.swift
@@ -41,6 +41,7 @@ final class SettingReactor: BaseReactor, Reactor {
     private let kakaoSigninManager: SigninManagerProtocol
     private let appleSigninManager: SigninManagerProtocol
     private let globalState: GlobalState
+    private let appInterface: AppModuleInterface
   
     init(
         userDefaults: UserDefaultsUtil,
@@ -50,6 +51,7 @@ final class SettingReactor: BaseReactor, Reactor {
         kakaoSigninManager: SigninManagerProtocol,
         appleSigninManager: SigninManagerProtocol,
         globalState: GlobalState,
+        appInterface: AppModuleInterface = AppModuleInterfaceImpl(),
         state: State = State(user: User())
     ) {
         self.userDefaults = userDefaults
@@ -59,6 +61,7 @@ final class SettingReactor: BaseReactor, Reactor {
         self.kakaoSigninManager = kakaoSigninManager
         self.appleSigninManager = appleSigninManager
         self.globalState = globalState
+        self.appInterface = appInterface
         self.initialState = state
         
         super.init()
@@ -159,6 +162,7 @@ final class SettingReactor: BaseReactor, Reactor {
                 )
                 .do(onNext: { [weak self] _ in
                     self?.analyticsManager.setPushEnable(isEnable: true)
+                    self?.appInterface.subscribeMarketingFCMTopic(completion: { _ in })
                 })
             }
             .map { _ in .setPushEnable(true) }
@@ -168,6 +172,7 @@ final class SettingReactor: BaseReactor, Reactor {
     private func setDisablePush() -> Observable<Mutation> {
         return self.deviceService.deleteDevice()
             .do(onNext: { [weak self] _ in
+                self?.appInterface.unsubscribeMarketingFCMTopic(completion: { _ in })
                 self?.analyticsManager.setPushEnable(isEnable: false)
             })
             .map { .setPushEnable(false) }

--- a/Modules/Common/Targets/Common/Sources/Util/UserDefaultsUtil.swift
+++ b/Modules/Common/Targets/Common/Sources/Util/UserDefaultsUtil.swift
@@ -54,6 +54,14 @@ public final class UserDefaultsUtil {
         }
     }
     
+    public var subscribedMarketingTopic: Bool {
+        get {
+            instance.bool(forKey: "KEY_SUBSCRIBE_MARKETING_TOPIC")
+        }
+        set {
+            instance.set(newValue, forKey: "KEY_SUBSCRIBE_MARKETING_TOPIC")
+        }
+    }
     
     public func setShownMainBannerDate(id: Int) {
         instance.set(DateUtils.todayString(), forKey: "KEY_SHOWN_MAIN_BANNER_\(id)")


### PR DESCRIPTION
### 변경사항
- 이미 마케팅 수신 동의한 사람들이 앱 진입할 경우, 최초 1회 판단하여 토픽 구독 호출
- 회원가입할 때 노출되는 마수동 팝업에서 동의 시 토픽 구독 호출
- FCM 토픽 구독/구독해제 함수 사용
- 설정화면에서 푸시 on/off 시에 토픽 구독, 구독 취소 호출