### PR TITLE
TH-114 : 애드몹 ID 인식 못하던 오류 수정

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -95,7 +95,12 @@ struct BuildSetting {
         ]
         
         static let debug: SettingsDictionary = [
-            "ADMOB_UNIT_ID": "ca-app-pub-3940256099942544/2934735716",
+            "ADMOB_UNIT_ID_POLL_DETAIL": "ca-app-pub-3940256099942544/2934735716",
+            "ADMOB_UNIT_ID_HOME_LIST": "ca-app-pub-3940256099942544/2934735716",
+            "ADMOB_UNIT_ID_HOME_CARD": "ca-app-pub-3940256099942544/2934735716",
+            "ADMOB_UNIT_ID_COMMUNITY": "ca-app-pub-3940256099942544/2934735716",
+            "ADMOB_UNIT_ID_CATEGORY_FILTER": "ca-app-pub-3940256099942544/2934735716",
+            "ADMOB_UNIT_ID_STORE_DETAIL": "ca-app-pub-3940256099942544/2934735716",
             "ANDROID_PACKAGE_NAME": "com.zion830.threedollars.dev",
             "API_URL": "https://dev.threedollars.co.kr",
             "APP_DISPLAY_NAME": "가슴속3천원-Dev",
@@ -111,7 +116,12 @@ struct BuildSetting {
         ]
         
         static let release: SettingsDictionary = [
-            "ADMOB_UNIT_ID": "ca-app-pub-1527951560812478/3327283605",
+            "ADMOB_UNIT_ID_POLL_DETAIL": "ca-app-pub-1527951560812478/5573281913",
+            "ADMOB_UNIT_ID_HOME_LIST": "ca-app-pub-1527951560812478/4059484724",
+            "ADMOB_UNIT_ID_HOME_CARD": "ca-app-pub-1527951560812478/4152389037",
+            "ADMOB_UNIT_ID_COMMUNITY": "ca-app-pub-1527951560812478/9021572333",
+            "ADMOB_UNIT_ID_CATEGORY_FILTER": "ca-app-pub-1527951560812478/3327283605",
+            "ADMOB_UNIT_ID_STORE_DETAIL": "ca-app-pub-1527951560812478/5208914863",
             "ANDROID_PACKAGE_NAME": "com.zion830.threedollars",
             "API_URL": "https://threedollars.co.kr",
             "APP_DISPLAY_NAME": "가슴속3천원",


### PR DESCRIPTION
### 변경내용
- 애드몹 캠페인 여러개로 만든 후, ID 인식 못하던 오류 수정