### PR TITLE
TH-187 : 최근 활동 필터 QA 수정

### DIFF
--- a/Modules/Core/Log/Sources/EventName.swift
+++ b/Modules/Core/Log/Sources/EventName.swift
@@ -23,6 +23,7 @@ public enum EventName: String {
     case clickAdCard = "click_ad_card"
     case clickAdMarker = "click_ad_marker"
     case clickAddress = "click_address"
+    case clickRecentActivityFilter = "click_recent_activity_filter"
     
     // 카테고리 필터 화면
     case clickCategory = "click_category"

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -283,6 +283,7 @@ final class HomeViewModel: BaseViewModel {
             .withUnretained(self)
             .handleEvents(receiveOutput: { (owner: HomeViewModel, _) in
                 owner.state.isOnlyRecentActivity.toggle()
+                owner.sendClickRecentActivityFilter(value: owner.state.isOnlyRecentActivity)
             })
             .asyncMap { owner, _ in
                 await owner.fetchAroundStore()
@@ -817,6 +818,14 @@ extension HomeViewModel {
             screen: output.screenName,
             eventName: .clickAdMarker,
             extraParameters: [.advertisementId: advertisement.advertisementId]
+        ))
+    }
+    
+    private func sendClickRecentActivityFilter(value: Bool) {
+        logManager.sendEvent(.init(
+            screen: output.screenName,
+            eventName: .clickRecentActivityFilter,
+            extraParameters: [.value: value]
         ))
     }
 }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -618,7 +618,7 @@ final class HomeViewModel: BaseViewModel {
             categoryIds = [filterCategory.category]
         }
         let targetStores: [StoreType] = state.isOnlyBossStore ? [.bossStore] : [.userStore, .bossStore]
-        let filterConditions: [String] = state.isOnlyRecentActivity ? ["RECENT_ACTIVITY"] : ["NO_RECENT_ACTIVITY"]
+        let filterConditions: [String] = state.isOnlyRecentActivity ? ["RECENT_ACTIVITY"] : ["RECENT_ACTIVITY", "NO_RECENT_ACTIVITY"]
         let input = FetchAroundStoreInput(
             distanceM: state.mapMaxDistance,
             categoryIds: categoryIds,

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
@@ -161,6 +161,7 @@ final class HomeListViewModel: BaseViewModel {
             .withUnretained(self)
             .handleEvents(receiveOutput: { (owner: HomeListViewModel, _) in
                 owner.state.isOnlyRecentActivity.toggle()
+                owner.sendClickRecentActivityFilter(value: owner.state.isOnlyRecentActivity)
             })
             .asyncMap { owner, _ in
                 await owner.fetchAroundStore()
@@ -383,7 +384,10 @@ final class HomeListViewModel: BaseViewModel {
         
         output.dataSource.send([HomeListSection(items: sectionItems)])
     }
-    
+}
+
+// MARK: Log
+extension HomeListViewModel {
     private func sendClickStore(_ storeCard: StoreCard) {
         logManager.sendEvent(.init(
             screen: output.screenName,
@@ -431,6 +435,14 @@ final class HomeListViewModel: BaseViewModel {
             screen: output.screenName,
             eventName: .clickOnlyVisit,
             extraParameters: [.value: isOn]
+        ))
+    }
+    
+    private func sendClickRecentActivityFilter(value: Bool) {
+        logManager.sendEvent(.init(
+            screen: output.screenName,
+            eventName: .clickRecentActivityFilter,
+            extraParameters: [.value: value]
         ))
     }
 }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
@@ -324,7 +324,7 @@ final class HomeListViewModel: BaseViewModel {
             categoryIds = [filterCategory.category]
         }
         let targetStores: [StoreType] = state.isOnlyBossStore ? [.bossStore] : [.userStore, .bossStore]
-        let filterConditions: [String] = state.isOnlyRecentActivity ? ["RECENT_ACTIVITY"] : ["NO_RECENT_ACTIVITY"]
+        let filterConditions: [String] = state.isOnlyRecentActivity ? ["RECENT_ACTIVITY"] : ["RECENT_ACTIVITY", "NO_RECENT_ACTIVITY"]
         let input = FetchAroundStoreInput(
             distanceM: state.mapMaxDistance,
             categoryIds: categoryIds,

--- a/Modules/Feature/Store/Targets/Store/Sources/Domains/StoreDetail/Subview/Cell/Visit/StoreDetailVisitCell.swift
+++ b/Modules/Feature/Store/Targets/Store/Sources/Domains/StoreDetail/Subview/Cell/Visit/StoreDetailVisitCell.swift
@@ -82,6 +82,7 @@ final class StoreDetailVisitCell: BaseCollectionViewCell {
             historyView.isHidden = true
         } else {
             emptyView.isHidden = true
+            historyView.isHidden = false
             historyView.bind(visit.histories, totalCount: visit.existsCounts + visit.notExistsCounts)
         }
     }


### PR DESCRIPTION
### 변경사항
- 최근 활동 필터 GA 이벤트 추가
- 최근 활동 필터 OFF시 서버 요청 파라미터 변경
- 가게 상세화면 진입 -> 방문 인증 없는 상태에서 방문 인증 하면 상세화면 바로 업데이트 되지 않는 이슈 수정