### PR TITLE
TH-212 : 사장님 가게 상세화면에서 에러 발생 시 에러 알럿 뜨도록 수정

### DIFF
--- a/Modules/Feature/Store/Targets/Store/Sources/Domains/BossStoreDetail/BossStoreDetailViewController.swift
+++ b/Modules/Feature/Store/Targets/Store/Sources/Domains/BossStoreDetail/BossStoreDetailViewController.swift
@@ -179,6 +179,14 @@ final class BossStoreDetailViewController: BaseViewController {
                 owner.collectionView.collectionViewLayout.invalidateLayout()
             }
             .store(in: &cancellables)
+        
+        viewModel.output.error
+            .main
+            .withUnretained(self)
+            .sink { (owner: BossStoreDetailViewController, error: Error) in
+                owner.showErrorAlert(error: error)
+            }
+            .store(in: &cancellables)
     }
 
     private func generateLayout() -> UICollectionViewLayout {


### PR DESCRIPTION
- [[ios/유저앱] (사장님 가게) 즐겨찾기 허용 최대 횟수를 넘어서면, 아무 메시지 없이 즐겨찾기가 안됩니다](https://3dollarinmypocket.atlassian.net/browse/TH-212)