### PR TITLE
TH-213 : 가게 리뷰 스티커 누르면, 메달 이미지 깨지는 이슈 수정

### DIFF
--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/Cell/PollDetailCommentCell.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Detail/Cell/PollDetailCommentCell.swift
@@ -6,7 +6,8 @@ import Then
 import Model
 
 final class PollDetailCommentCell: BaseCollectionViewCell {
-
+    private let feedbackGenerator = UISelectionFeedbackGenerator()
+    
     enum Layout {
         static func height(content: String) -> CGFloat {
             return content.height(font: Fonts.regular.font(size: 14), width: UIScreen.main.bounds.width - 40) + 106
@@ -87,6 +88,7 @@ final class PollDetailCommentCell: BaseCollectionViewCell {
         dateStackView.addArrangedSubview(reportOrUpdateButton)
 
         dateStackView.setCustomSpacing(2, after: dateSideDotView)
+        feedbackGenerator.prepare()
     }
 
     override func bindConstraints() {
@@ -141,6 +143,9 @@ final class PollDetailCommentCell: BaseCollectionViewCell {
         likeButton.controlPublisher(for: .touchUpInside)
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .mapVoid
+            .handleEvents(receiveOutput: { [weak self] _ in
+                self?.feedbackGenerator.selectionChanged()
+            })
             .subscribe(viewModel.input.didTapReviewLikeButton)
             .store(in: &cancellables)
 

--- a/Modules/Feature/Store/Targets/Store/Sources/Domains/StoreDetail/Subview/Cell/Review/StoreDetailMedalBadgeView.swift
+++ b/Modules/Feature/Store/Targets/Store/Sources/Domains/StoreDetail/Subview/Cell/Review/StoreDetailMedalBadgeView.swift
@@ -68,6 +68,11 @@ final class StoreDetailMedalBadgeView: BaseView {
         }
     }
     
+    func prepareForReuse() {
+        badgeImgaeView.image = nil
+        titleLabel.text = nil
+    }
+    
     func bind(_ medal: Medal) {
         badgeImgaeView.setImage(urlString: medal.iconUrl)
         titleLabel.text = medal.name

--- a/Modules/Feature/Store/Targets/Store/Sources/Domains/StoreDetail/Subview/Cell/Review/StoreDetailReviewCell.swift
+++ b/Modules/Feature/Store/Targets/Store/Sources/Domains/StoreDetail/Subview/Cell/Review/StoreDetailReviewCell.swift
@@ -73,6 +73,7 @@ final class StoreDetailReviewCell: BaseCollectionViewCell {
         super.prepareForReuse()
         
         starBadge.prepareForReuse()
+        medalBadge.prepareForReuse()
     }
     
     override func setup() {


### PR DESCRIPTION
- [[ios/유저앱] 가게 리뷰 스티커 누르면, 칭호가 위에 유저껄로 변경됨](https://3dollarinmypocket.atlassian.net/browse/TH-213)
- 투표 댓글 좋아요 터치 시, 진동 피드백 설정