### PR TITLE
TH-219 : 최근 검색 화면 에러 처리 추가

### DIFF
--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/SearchAddress/SearchAddressViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/SearchAddress/SearchAddressViewModel.swift
@@ -103,7 +103,7 @@ final class SearchAddressViewModel: BaseViewModel {
             .mapVoid
             .share()
         
-        input.firstLoad
+        let loadRecentSearch = input.firstLoad
             .merge(with: loadMore)
             .withUnretained(self)
             .filter { owner, _ in
@@ -121,11 +121,19 @@ final class SearchAddressViewModel: BaseViewModel {
                     )
                 )
             }
+            .share()
+        
+        loadRecentSearch
             .compactMapValue()
             .withUnretained(self)
             .sink { owner, result in
                 owner.handleRecentSearchAddressResult(result)
             }
+            .store(in: &cancellables)
+        
+        loadRecentSearch
+            .compactMapError()
+            .subscribe(output.showErrorAlert)
             .store(in: &cancellables)
         
         input.didTapRecentSearchAddress


### PR DESCRIPTION
- [[iOS/유저앱] 주소 검색 화면에서 최근 검색어 API 에러 발생 시, 에러처리 안되어있음](https://3dollarinmypocket.atlassian.net/browse/TH-219)