### PR TITLE
TH-1261 : 홈 리스트 focusBounds 에 맞춰 지도 범위 이동

### DIFF
--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/main/MainTabBarViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/main/MainTabBarViewController.swift
@@ -109,6 +109,10 @@ final class MainTabBarViewController: UITabBarController {
         self.setTabBarColor(tab: tab)
     }
     
+    func applyHomePreset(_ preset: String) {
+        homeViewController.applyPreset(preset)
+    }
+
     func showLoading(isShow: Bool) {
         LoadingManager.shared.showLoading(isShow: isShow)
     }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/manager/deeplink/DeepLinkHandler.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/manager/deeplink/DeepLinkHandler.swift
@@ -31,6 +31,13 @@ final class DeepLinkHandler: DeepLinkHandlerProtocol {
     
     private var reservedDeepLink: String?
     
+    private var mainTabBarViewController: MainTabBarViewController? {
+        let rootViewController = SceneDelegate.shared?.window?.rootViewController
+        let navigationViewController = rootViewController as? UINavigationController
+
+        return navigationViewController?.topViewController as? MainTabBarViewController
+    }
+    
     func reservedDeepLinkExisted() -> Bool {
         return reservedDeepLink.isNotNil
     }
@@ -110,6 +117,11 @@ final class DeepLinkHandler: DeepLinkHandlerProtocol {
             route(viewController)
         case .home:
             moveTab(.home)
+
+            if let params = url.params(),
+               let preset = params["preset"] as? String {
+                mainTabBarViewController?.applyHomePreset(preset)
+            }
         case .medal:
             let targetViewController = Environment.myPageInterface.getMyMedalViewController()
             route(targetViewController)
@@ -192,21 +204,18 @@ final class DeepLinkHandler: DeepLinkHandlerProtocol {
         handle(reservedDeepLink)
         self.reservedDeepLink = nil
     }
-    
+
     private func moveTab(_ tab: TabBarTag) {
         let rootViewController = SceneDelegate.shared?.window?.rootViewController
-        
+
         if let rootViewController {
             let topViewController = UIUtils.getTopViewController(rootViewController)
             if topViewController.isPanModalPresented == true {
                 topViewController.dismiss(animated: true)
             }
         }
-        
-        if let navigationViewController = rootViewController as? UINavigationController,
-           let tabBarViewController = navigationViewController.topViewController as? MainTabBarViewController {
-            tabBarViewController.selectTab(tab: tab)
-        }
+
+        mainTabBarViewController?.selectTab(tab: tab)
     }
     
     private func isAppScheme(url: URL) -> Bool {

--- a/App/Targets/three-dollar-in-my-pocketTests/Resources/HomeListSectionWithFocusBounds.json
+++ b/App/Targets/three-dollar-in-my-pocketTests/Resources/HomeListSectionWithFocusBounds.json
@@ -1,0 +1,320 @@
+{
+  "cards": [
+    {
+      "type": "BASIC_CARD",
+      "cardId": "S:55",
+      "header": {
+        "title": {
+          "text": "<span style=\"font-size:16px; font-weight:700; color:#0F0F0F\">서울 광장</span>",
+          "isHtml": true,
+          "fontColor": "#0F0F0F"
+        }
+      },
+      "metadata": {
+        "primary": [
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">와플, 순대</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          },
+          {
+            "image": {
+              "url": "https://storage.threedollars.co.kr/app/star_solid_bold.png",
+              "style": {
+                "width": 16.0,
+                "height": 16.0
+              }
+            },
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#5A5A5A\">0.0 (0)</span>",
+              "isHtml": true,
+              "fontColor": "#5A5A5A"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          }
+        ],
+        "secondary": [
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">5m</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          },
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">최근 방문 0명</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          }
+        ],
+        "separator": {
+          "url": "https://storage.threedollars.co.kr/app/rectangle_465.png",
+          "style": {
+            "width": 2.0,
+            "height": 2.0
+          }
+        }
+      },
+      "images": [],
+      "bodies": [],
+      "marker": {
+        "focused": {
+          "image": {
+            "url": "https://storage.threedollars.co.kr/app/marker/boss_mappin_focused_14.png",
+            "style": {
+              "width": 32.0,
+              "height": 40.0
+            }
+          },
+          "style": {
+            "backgroundColor": "#FF5C43"
+          }
+        },
+        "unfocused": {
+          "image": {
+            "url": "https://storage.threedollars.co.kr/app/marker/boss_mappin_unfocused_14.png",
+            "style": {
+              "width": 28.0,
+              "height": 28.0
+            }
+          },
+          "style": {
+            "backgroundColor": "#FF5C43"
+          }
+        },
+        "location": {
+          "latitude": 37.566536,
+          "longitude": 126.977966
+        },
+        "link": {
+          "type": "APP_SCHEME",
+          "link": "/store?storeType=USER_STORE&storeId=55"
+        },
+        "clickLog": {
+          "eventType": "CLICK",
+          "screenName": "home",
+          "objectType": "marker",
+          "objectId": "store",
+          "extraParameters": {
+            "store_id": "55",
+            "store_type": "USER_STORE"
+          }
+        }
+      },
+      "link": {
+        "type": "APP_SCHEME",
+        "link": "/store?storeType=USER_STORE&storeId=55"
+      },
+      "style": {
+        "backgroundColor": "#FFFFFF"
+      },
+      "refs": [
+        {
+          "type": "STORE",
+          "storeId": "55",
+          "storeType": "USER_STORE"
+        }
+      ],
+      "clickLog": {
+        "eventType": "CLICK",
+        "screenName": "home",
+        "objectType": "card",
+        "objectId": "store",
+        "extraParameters": {
+          "store_id": "55",
+          "store_type": "USER_STORE"
+        }
+      },
+      "impressionLog": {
+        "eventType": "IMPRESSION",
+        "screenName": "home",
+        "objectType": "card",
+        "objectId": "store",
+        "extraParameters": {
+          "store_id": "55",
+          "store_type": "USER_STORE"
+        }
+      }
+    },
+    {
+      "type": "BASIC_CARD",
+      "cardId": "S:52",
+      "header": {
+        "title": {
+          "text": "<span style=\"font-size:16px; font-weight:700; color:#0F0F0F\">스타벅스</span>",
+          "isHtml": true,
+          "fontColor": "#0F0F0F"
+        }
+      },
+      "metadata": {
+        "primary": [
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">붕어빵</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          },
+          {
+            "image": {
+              "url": "https://storage.threedollars.co.kr/app/star_solid_bold.png",
+              "style": {
+                "width": 16.0,
+                "height": 16.0
+              }
+            },
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#5A5A5A\">0.0 (0)</span>",
+              "isHtml": true,
+              "fontColor": "#5A5A5A"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          }
+        ],
+        "secondary": [
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">5m</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          },
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">최근 방문 0명</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          }
+        ],
+        "separator": {
+          "url": "https://storage.threedollars.co.kr/app/rectangle_465.png",
+          "style": {
+            "width": 2.0,
+            "height": 2.0
+          }
+        }
+      },
+      "images": [],
+      "bodies": [],
+      "marker": {
+        "focused": {
+          "image": {
+            "url": "https://storage.threedollars.co.kr/app/marker/boss_mappin_focused_01.png",
+            "style": {
+              "width": 32.0,
+              "height": 40.0
+            }
+          },
+          "style": {
+            "backgroundColor": "#FF5C43"
+          }
+        },
+        "unfocused": {
+          "image": {
+            "url": "https://storage.threedollars.co.kr/app/marker/boss_mappin_unfocused_01.png",
+            "style": {
+              "width": 28.0,
+              "height": 28.0
+            }
+          },
+          "style": {
+            "backgroundColor": "#FF5C43"
+          }
+        },
+        "location": {
+          "latitude": 37.566536,
+          "longitude": 126.977966
+        },
+        "link": {
+          "type": "APP_SCHEME",
+          "link": "/store?storeType=USER_STORE&storeId=52"
+        },
+        "clickLog": {
+          "eventType": "CLICK",
+          "screenName": "home",
+          "objectType": "marker",
+          "objectId": "store",
+          "extraParameters": {
+            "store_id": "52",
+            "store_type": "USER_STORE"
+          }
+        }
+      },
+      "link": {
+        "type": "APP_SCHEME",
+        "link": "/store?storeType=USER_STORE&storeId=52"
+      },
+      "style": {
+        "backgroundColor": "#FFFFFF"
+      },
+      "refs": [
+        {
+          "type": "STORE",
+          "storeId": "52",
+          "storeType": "USER_STORE"
+        }
+      ],
+      "clickLog": {
+        "eventType": "CLICK",
+        "screenName": "home",
+        "objectType": "card",
+        "objectId": "store",
+        "extraParameters": {
+          "store_id": "52",
+          "store_type": "USER_STORE"
+        }
+      },
+      "impressionLog": {
+        "eventType": "IMPRESSION",
+        "screenName": "home",
+        "objectType": "card",
+        "objectId": "store",
+        "extraParameters": {
+          "store_id": "52",
+          "store_type": "USER_STORE"
+        }
+      }
+    }
+  ],
+  "cursor": {
+    "nextCursor": "GM3S4NJWGY2TUORRGI3C4OJXHA5DUMROGA5DUMBOGEYDMMZSHE2DAMZUHAYTOOJSGA3Q====",
+    "hasMore": true
+  },
+  "focusBounds": {
+    "southWest": {
+      "latitude": 37.56566954184981,
+      "longitude": 126.977966
+    },
+    "northEast": {
+      "latitude": 37.5666,
+      "longitude": 126.97871680558559
+    }
+  }
+}

--- a/App/Targets/three-dollar-in-my-pocketTests/Resources/HomeListSectionWithoutFocusBounds.json
+++ b/App/Targets/three-dollar-in-my-pocketTests/Resources/HomeListSectionWithoutFocusBounds.json
@@ -1,0 +1,310 @@
+{
+  "cards": [
+    {
+      "type": "BASIC_CARD",
+      "cardId": "S:55",
+      "header": {
+        "title": {
+          "text": "<span style=\"font-size:16px; font-weight:700; color:#0F0F0F\">서울 광장</span>",
+          "isHtml": true,
+          "fontColor": "#0F0F0F"
+        }
+      },
+      "metadata": {
+        "primary": [
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">와플, 순대</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          },
+          {
+            "image": {
+              "url": "https://storage.threedollars.co.kr/app/star_solid_bold.png",
+              "style": {
+                "width": 16.0,
+                "height": 16.0
+              }
+            },
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#5A5A5A\">0.0 (0)</span>",
+              "isHtml": true,
+              "fontColor": "#5A5A5A"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          }
+        ],
+        "secondary": [
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">5m</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          },
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">최근 방문 0명</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          }
+        ],
+        "separator": {
+          "url": "https://storage.threedollars.co.kr/app/rectangle_465.png",
+          "style": {
+            "width": 2.0,
+            "height": 2.0
+          }
+        }
+      },
+      "images": [],
+      "bodies": [],
+      "marker": {
+        "focused": {
+          "image": {
+            "url": "https://storage.threedollars.co.kr/app/marker/boss_mappin_focused_14.png",
+            "style": {
+              "width": 32.0,
+              "height": 40.0
+            }
+          },
+          "style": {
+            "backgroundColor": "#FF5C43"
+          }
+        },
+        "unfocused": {
+          "image": {
+            "url": "https://storage.threedollars.co.kr/app/marker/boss_mappin_unfocused_14.png",
+            "style": {
+              "width": 28.0,
+              "height": 28.0
+            }
+          },
+          "style": {
+            "backgroundColor": "#FF5C43"
+          }
+        },
+        "location": {
+          "latitude": 37.566536,
+          "longitude": 126.977966
+        },
+        "link": {
+          "type": "APP_SCHEME",
+          "link": "/store?storeType=USER_STORE&storeId=55"
+        },
+        "clickLog": {
+          "eventType": "CLICK",
+          "screenName": "home",
+          "objectType": "marker",
+          "objectId": "store",
+          "extraParameters": {
+            "store_id": "55",
+            "store_type": "USER_STORE"
+          }
+        }
+      },
+      "link": {
+        "type": "APP_SCHEME",
+        "link": "/store?storeType=USER_STORE&storeId=55"
+      },
+      "style": {
+        "backgroundColor": "#FFFFFF"
+      },
+      "refs": [
+        {
+          "type": "STORE",
+          "storeId": "55",
+          "storeType": "USER_STORE"
+        }
+      ],
+      "clickLog": {
+        "eventType": "CLICK",
+        "screenName": "home",
+        "objectType": "card",
+        "objectId": "store",
+        "extraParameters": {
+          "store_id": "55",
+          "store_type": "USER_STORE"
+        }
+      },
+      "impressionLog": {
+        "eventType": "IMPRESSION",
+        "screenName": "home",
+        "objectType": "card",
+        "objectId": "store",
+        "extraParameters": {
+          "store_id": "55",
+          "store_type": "USER_STORE"
+        }
+      }
+    },
+    {
+      "type": "BASIC_CARD",
+      "cardId": "S:52",
+      "header": {
+        "title": {
+          "text": "<span style=\"font-size:16px; font-weight:700; color:#0F0F0F\">스타벅스</span>",
+          "isHtml": true,
+          "fontColor": "#0F0F0F"
+        }
+      },
+      "metadata": {
+        "primary": [
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">붕어빵</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          },
+          {
+            "image": {
+              "url": "https://storage.threedollars.co.kr/app/star_solid_bold.png",
+              "style": {
+                "width": 16.0,
+                "height": 16.0
+              }
+            },
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#5A5A5A\">0.0 (0)</span>",
+              "isHtml": true,
+              "fontColor": "#5A5A5A"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          }
+        ],
+        "secondary": [
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">5m</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          },
+          {
+            "text": {
+              "text": "<span style=\"font-size:14px; font-weight:400; color:#787878\">최근 방문 0명</span>",
+              "isHtml": true,
+              "fontColor": "#787878"
+            },
+            "style": {
+              "backgroundColor": "#FFFFFF"
+            }
+          }
+        ],
+        "separator": {
+          "url": "https://storage.threedollars.co.kr/app/rectangle_465.png",
+          "style": {
+            "width": 2.0,
+            "height": 2.0
+          }
+        }
+      },
+      "images": [],
+      "bodies": [],
+      "marker": {
+        "focused": {
+          "image": {
+            "url": "https://storage.threedollars.co.kr/app/marker/boss_mappin_focused_01.png",
+            "style": {
+              "width": 32.0,
+              "height": 40.0
+            }
+          },
+          "style": {
+            "backgroundColor": "#FF5C43"
+          }
+        },
+        "unfocused": {
+          "image": {
+            "url": "https://storage.threedollars.co.kr/app/marker/boss_mappin_unfocused_01.png",
+            "style": {
+              "width": 28.0,
+              "height": 28.0
+            }
+          },
+          "style": {
+            "backgroundColor": "#FF5C43"
+          }
+        },
+        "location": {
+          "latitude": 37.566536,
+          "longitude": 126.977966
+        },
+        "link": {
+          "type": "APP_SCHEME",
+          "link": "/store?storeType=USER_STORE&storeId=52"
+        },
+        "clickLog": {
+          "eventType": "CLICK",
+          "screenName": "home",
+          "objectType": "marker",
+          "objectId": "store",
+          "extraParameters": {
+            "store_id": "52",
+            "store_type": "USER_STORE"
+          }
+        }
+      },
+      "link": {
+        "type": "APP_SCHEME",
+        "link": "/store?storeType=USER_STORE&storeId=52"
+      },
+      "style": {
+        "backgroundColor": "#FFFFFF"
+      },
+      "refs": [
+        {
+          "type": "STORE",
+          "storeId": "52",
+          "storeType": "USER_STORE"
+        }
+      ],
+      "clickLog": {
+        "eventType": "CLICK",
+        "screenName": "home",
+        "objectType": "card",
+        "objectId": "store",
+        "extraParameters": {
+          "store_id": "52",
+          "store_type": "USER_STORE"
+        }
+      },
+      "impressionLog": {
+        "eventType": "IMPRESSION",
+        "screenName": "home",
+        "objectType": "card",
+        "objectId": "store",
+        "extraParameters": {
+          "store_id": "52",
+          "store_type": "USER_STORE"
+        }
+      }
+    }
+  ],
+  "cursor": {
+    "nextCursor": "GM3S4NJWGY2TUORRGI3C4OJXHA5DUMROGA5DUMBOGEYDMMZSHE2DAMZUHAYTOOJSGA3Q====",
+    "hasMore": true
+  }
+}

--- a/App/Targets/three-dollar-in-my-pocketTests/Sources/ModelTests/HomeListSectionResponseTests.swift
+++ b/App/Targets/three-dollar-in-my-pocketTests/Sources/ModelTests/HomeListSectionResponseTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+
+import Model
+
+final class HomeListSectionResponseTests: XCTestCase {
+    func test_이벤트가게필터응답을디코딩하면_focusBounds가파싱된다() throws {
+        // Given & When
+        let response = try FixtureLoader.decode(
+            HomeListSectionResponse.self,
+            from: "HomeListSectionWithFocusBounds"
+        )
+
+        // Then
+        let focusBounds = try XCTUnwrap(response.focusBounds)
+        XCTAssertEqual(focusBounds.southWest.latitude, 37.56566954184981, accuracy: 0.000001)
+        XCTAssertEqual(focusBounds.southWest.longitude, 126.977966, accuracy: 0.000001)
+        XCTAssertEqual(focusBounds.northEast.latitude, 37.5666, accuracy: 0.000001)
+        XCTAssertEqual(focusBounds.northEast.longitude, 126.97871680558559, accuracy: 0.000001)
+    }
+
+    func test_focusBounds가없는응답을디코딩하면_nil이고기존필드는유지된다() throws {
+        // Given & When
+        let response = try FixtureLoader.decode(
+            HomeListSectionResponse.self,
+            from: "HomeListSectionWithoutFocusBounds"
+        )
+
+        // Then
+        XCTAssertNil(response.focusBounds)
+        XCTAssertFalse(response.cards.isEmpty)
+        XCTAssertEqual(response.cursor?.hasMore, true)
+        XCTAssertNotNil(response.cursor?.nextCursor)
+    }
+
+    func test_focusBounds가있어도_카드와커서파싱은그대로동작한다() throws {
+        // Given & When
+        let withBounds = try FixtureLoader.decode(
+            HomeListSectionResponse.self,
+            from: "HomeListSectionWithFocusBounds"
+        )
+        let withoutBounds = try FixtureLoader.decode(
+            HomeListSectionResponse.self,
+            from: "HomeListSectionWithoutFocusBounds"
+        )
+
+        // Then
+        XCTAssertEqual(withBounds.cards.count, withoutBounds.cards.count)
+        XCTAssertEqual(
+            withBounds.cards.map(\.cardId),
+            withoutBounds.cards.map(\.cardId)
+        )
+        XCTAssertEqual(withBounds.cursor?.nextCursor, withoutBounds.cursor?.nextCursor)
+    }
+
+    func test_남서북동좌표가같은focusBounds도_디코딩된다() throws {
+        // Given
+        let json = """
+        {
+            "cards": [],
+            "cursor": { "nextCursor": null, "hasMore": false },
+            "focusBounds": {
+                "southWest": { "latitude": 37.5665, "longitude": 126.978 },
+                "northEast": { "latitude": 37.5665, "longitude": 126.978 }
+            }
+        }
+        """
+
+        // When
+        let response = try JSONDecoder().decode(
+            HomeListSectionResponse.self,
+            from: XCTUnwrap(json.data(using: .utf8))
+        )
+
+        // Then
+        let focusBounds = try XCTUnwrap(response.focusBounds)
+        XCTAssertEqual(focusBounds.southWest, focusBounds.northEast)
+        XCTAssertTrue(response.cards.isEmpty)
+        XCTAssertEqual(response.cursor?.hasMore, false)
+    }
+}

--- a/App/Targets/three-dollar-in-my-pocketTests/Sources/Support/FixtureLoader.swift
+++ b/App/Targets/three-dollar-in-my-pocketTests/Sources/Support/FixtureLoader.swift
@@ -1,0 +1,26 @@
+import Foundation
+import XCTest
+
+enum FixtureLoader {
+    /// 테스트 번들의 JSON 픽스처를 디코딩한다. 픽스처는 dev 서버 실응답에서 캡처한다.
+    static func decode<T: Decodable>(
+        _ type: T.Type,
+        from fileName: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> T {
+        let bundle = Bundle(for: BundleToken.self)
+        guard let url = bundle.url(forResource: fileName, withExtension: "json") else {
+            XCTFail("픽스처를 찾을 수 없습니다: \(fileName).json", file: file, line: line)
+            throw FixtureError.notFound(fileName)
+        }
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    enum FixtureError: Error {
+        case notFound(String)
+    }
+}
+
+private final class BundleToken { }

--- a/Modules/Core/Model/Sources/Domain/Input/FetchHomeFilterScreenInput.swift
+++ b/Modules/Core/Model/Sources/Domain/Input/FetchHomeFilterScreenInput.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct FetchHomeFilterScreenInput: Encodable {
+    public let preset: String?
+
+    public init(preset: String? = nil) {
+        self.preset = preset
+    }
+}

--- a/Modules/Core/Model/Sources/Domain/Response/HomeListSectionResponse.swift
+++ b/Modules/Core/Model/Sources/Domain/Response/HomeListSectionResponse.swift
@@ -3,20 +3,28 @@ import Foundation
 public struct HomeListSectionResponse: Decodable {
     public let cards: [any HomeListCardComponent]
     public let cursor: CursorString?
+    public let focusBounds: LocationBoundsResponse?
 
     public enum CodingKeys: String, CodingKey {
         case cards
         case cursor
+        case focusBounds
     }
 
-    public init(cards: [any HomeListCardComponent], cursor: CursorString?) {
+    public init(
+        cards: [any HomeListCardComponent],
+        cursor: CursorString?,
+        focusBounds: LocationBoundsResponse? = nil
+    ) {
         self.cards = cards
         self.cursor = cursor
+        self.focusBounds = focusBounds
     }
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.cursor = try container.decodeIfPresent(CursorString.self, forKey: .cursor)
+        self.focusBounds = try container.decodeIfPresent(LocationBoundsResponse.self, forKey: .focusBounds)
 
         var cardsArray = try container.nestedUnkeyedContainer(forKey: .cards)
         var typeProbe = cardsArray

--- a/Modules/Core/Model/Sources/Domain/Response/LocationBoundsResponse.swift
+++ b/Modules/Core/Model/Sources/Domain/Response/LocationBoundsResponse.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct LocationBoundsResponse: Decodable, Hashable {
+    public let southWest: LocationResponse
+    public let northEast: LocationResponse
+
+    public init(southWest: LocationResponse, northEast: LocationResponse) {
+        self.southWest = southWest
+        self.northEast = northEast
+    }
+}

--- a/Modules/Core/Network/Sources/API/ScreenApi.swift
+++ b/Modules/Core/Network/Sources/API/ScreenApi.swift
@@ -3,15 +3,15 @@ import Foundation
 import Model
 
 enum ScreenApi {
-    case fetchHomeFilterScreen
+    case fetchHomeFilterScreen(input: FetchHomeFilterScreenInput)
     case fetchHomeSectionList(input: FetchHomeSectionListInput)
 }
 
 extension ScreenApi: RequestType {
     var param: (any Encodable)? {
         switch self {
-        case .fetchHomeFilterScreen:
-            return nil
+        case .fetchHomeFilterScreen(let input):
+            return input
         case .fetchHomeSectionList(let input):
             return input
         }

--- a/Modules/Core/Network/Sources/Repository/ScreenRepository.swift
+++ b/Modules/Core/Network/Sources/Repository/ScreenRepository.swift
@@ -3,15 +3,15 @@ import Foundation
 import Model
 
 public protocol ScreenRepository {
-    func fetchHomeFilterScreen() async -> Result<HomeFilterScreenResponse, Error>
+    func fetchHomeFilterScreen(input: FetchHomeFilterScreenInput) async -> Result<HomeFilterScreenResponse, Error>
     func fetchHomeSectionList(input: FetchHomeSectionListInput) async -> Result<HomeListSectionResponse, Error>
 }
 
 public final class ScreenRepositoryImpl: ScreenRepository {
     public init() { }
 
-    public func fetchHomeFilterScreen() async -> Result<HomeFilterScreenResponse, Error> {
-        let request = ScreenApi.fetchHomeFilterScreen
+    public func fetchHomeFilterScreen(input: FetchHomeFilterScreenInput) async -> Result<HomeFilterScreenResponse, Error> {
+        let request = ScreenApi.fetchHomeFilterScreen(input: input)
         return await NetworkManager.shared.request(requestType: request)
     }
 

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeView.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeView.swift
@@ -9,6 +9,10 @@ import SnapKit
 import Then
 
 final class HomeView: BaseView {
+    enum Layout {
+        static let focusBoundsPadding: CGFloat = 24
+    }
+
     /// 바텀시트 short form 의 가시 영역 높이. HomeListLayout.Layout.tipVisibleHeight 와 동일.
     private let bottomSheetShortFormHeight: CGFloat = HomeListLayout.Layout.tipVisibleHeight
 
@@ -160,6 +164,22 @@ final class HomeView: BaseView {
         )
         let cameraUpdate = NMFCameraUpdate(position: cameraPosition)
         
+        cameraUpdate.animation = .easeIn
+        mapView.moveCamera(cameraUpdate)
+    }
+
+    func moveCamera(bounds: LocationBoundsResponse) {
+        let southWest = NMGLatLng(lat: bounds.southWest.latitude, lng: bounds.southWest.longitude)
+        let northEast = NMGLatLng(lat: bounds.northEast.latitude, lng: bounds.northEast.longitude)
+        let latLngBounds = NMGLatLngBounds(southWest: southWest, northEast: northEast)
+        let paddingInsets = UIEdgeInsets(
+            top: homeFilterCollectionView.frame.maxY + Layout.focusBoundsPadding,
+            left: Layout.focusBoundsPadding,
+            bottom: safeAreaInsets.bottom + bottomSheetShortFormHeight + Layout.focusBoundsPadding,
+            right: Layout.focusBoundsPadding
+        )
+        let cameraUpdate = NMFCameraUpdate(fit: latLngBounds, paddingInsets: paddingInsets)
+
         cameraUpdate.animation = .easeIn
         mapView.moveCamera(cameraUpdate)
     }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewController.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewController.swift
@@ -106,6 +106,10 @@ public final class HomeViewController: BaseViewController {
         storePreviewBottomSheetController?.view.isHidden = true
     }
 
+    public func applyPreset(_ preset: String) {
+        viewModel.input.applyPreset.send(preset)
+    }
+
     public override func sendPageView() {
         super.sendPageView()
 

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewController.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewController.swift
@@ -182,6 +182,14 @@ public final class HomeViewController: BaseViewController {
             }
             .store(in: &cancellables)
 
+        viewModel.output.focusBounds
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { (owner: HomeViewController, bounds: LocationBoundsResponse) in
+                owner.homeView.moveCamera(bounds: bounds)
+            }
+            .store(in: &cancellables)
+
         viewModel.output.advertisementMarker
             .main
             .withUnretained(self)

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -39,6 +39,7 @@ extension HomeViewModel {
         let onTapMarker = PassthroughSubject<Int, Never>()
         let onTapCurrentMarker = PassthroughSubject<Void, Never>()
         let didTapFeedButton = PassthroughSubject<Void, Never>()
+        let applyPreset = PassthroughSubject<String, Never>()
 
         // From bottom sheet
         let bottomSheetWillLoadMore = PassthroughSubject<Void, Never>()
@@ -75,6 +76,7 @@ extension HomeViewModel {
         var filterSections: [any HomeScreenSection] = []
         var radioSelection: [String: Int] = [:]
         var hasLoadedFilterScreen = false
+        var preset: String?
         var initialMapZoomLevel: Double?
         var mapMaxDistance: Double?
         var newCameraPosition: CLLocation?
@@ -210,6 +212,14 @@ final class HomeViewModel: BaseViewModel {
             .sink(receiveValue: { [weak self] in
                 self?.presentPolicyIfNeeded()
                 self?.fetchFilterScreen()
+            })
+            .store(in: &cancellables)
+
+        input.applyPreset
+            .withUnretained(self)
+            .sink(receiveValue: { (owner: HomeViewModel, preset: String) in
+                owner.state.preset = preset
+                owner.fetchFilterScreen(shouldRefreshCards: true)
             })
             .store(in: &cancellables)
 
@@ -702,17 +712,21 @@ extension HomeViewModel {
         output.filterDatasource.send(datasource)
     }
 
-    private func fetchFilterScreen() {
+    private func fetchFilterScreen(shouldRefreshCards: Bool = false) {
         Task { @MainActor in
-            let result = await dependency.screenRepository.fetchHomeFilterScreen()
+            let input = FetchHomeFilterScreenInput(preset: state.preset)
+            let result = await dependency.screenRepository.fetchHomeFilterScreen(input: input)
             switch result {
             case .success(let response):
                 state.filterSections = response.sections
                 state.hasLoadedFilterScreen = true
                 state.initialMapZoomLevel = response.configuration?.initialMapZoomLevel
-                initializeRadioSelectionDefaults()
-                syncRadioSelectionFromLegacy()
+                applyServerSelectionDefaults()
                 output.filterDatasource.send(flattenFilterDatasource())
+
+                if shouldRefreshCards && state.resultCameraPosition.isNotNil {
+                    fetchInitialCards()
+                }
             case .failure:
                 output.filterDatasource.send(makeFallbackFilterDatasource())
             }
@@ -728,12 +742,11 @@ extension HomeViewModel {
             .flatMap(\.bars)
     }
 
-    private func initializeRadioSelectionDefaults() {
-        for case let radioBar as HomeFilterRadioBar in allBars where state.radioSelection[radioBar.paramKey] == nil {
+    private func applyServerSelectionDefaults() {
+        state.radioSelection = [:]
+        for case let radioBar as HomeFilterRadioBar in allBars {
             state.radioSelection[radioBar.paramKey] = 0
-            if let firstOption = radioBar.options.first {
-                applyParamValueToLegacyState(paramKey: radioBar.paramKey, paramValue: firstOption.paramValue)
-            }
+            applyParamValueToLegacyState(paramKey: radioBar.paramKey, paramValue: radioBar.options.first?.paramValue)
         }
     }
 

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -51,6 +51,7 @@ extension HomeViewModel {
         let filterDatasource = CurrentValueSubject<[HomeFilterCollectionView.CellType], Never>([])
         let isHiddenResearchButton = PassthroughSubject<Bool, Never>()
         let cameraPosition = PassthroughSubject<(CLLocation, Double?), Never>()
+        let focusBounds = PassthroughSubject<LocationBoundsResponse, Never>()
         let advertisementMarker = PassthroughSubject<AdvertisementResponse, Never>()
         /// 바텀시트로 전달할 카드 목록.
         let bottomSheetCards = CurrentValueSubject<[any HomeListCardComponent], Never>([])
@@ -468,6 +469,10 @@ final class HomeViewModel: BaseViewModel {
                 state.nextCursor = response.cursor?.nextCursor
                 state.hasMore = response.cursor?.hasMore ?? false
                 emitCards()
+
+                if let focusBounds = response.focusBounds {
+                    output.focusBounds.send(focusBounds)
+                }
             case .failure(let error):
                 output.route.send(.showErrorAlert(error))
             }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -155,6 +155,12 @@ final class HomeViewModel: BaseViewModel {
     private let filterScreenLoaded = PassthroughSubject<Void, Never>()
     private var loadTask: Task<Void, Never>?
     private var loadMoreTask: Task<Void, Never>?
+    
+    private var allBars: [any HomeFilterBar] {
+        state.filterSections
+            .compactMap { $0 as? HomeFilterSection }
+            .flatMap(\.bars)
+    }
 
     init(dependency: Dependency = Dependency()) {
         self.dependency = dependency
@@ -734,12 +740,6 @@ extension HomeViewModel {
             filterScreenLoaded.send()
         }
         .store(in: taskBag)
-    }
-
-    private var allBars: [any HomeFilterBar] {
-        state.filterSections
-            .compactMap { $0 as? HomeFilterSection }
-            .flatMap(\.bars)
     }
 
     private func applyServerSelectionDefaults() {


### PR DESCRIPTION
## 작업 내용

[TH-1261](https://3dollarinmypocket.atlassian.net/browse/TH-1261) — 홈 리스트 섹션 API(`GET /v1/screen/home/section/list`)에 추가된 `focusBounds` 필드를 반영합니다.

`focusBounds` 가 내려오면 해당 범위가 지도에 모두 보이도록 카메라의 **position 과 zoom level** 을 함께 맞춥니다. 필드가 없으면(`null`) 기존과 동일하게 카메라를 건드리지 않습니다. 리스트 바텀시트 동작은 그대로 유지됩니다.

이벤트성 가게 필터(`customFilterType=EVENT_STORES`)는 서버가 홈 필터 섹션에 `RADIO_BAR(paramKey: customFilterType)` 로 내려주고, 클라이언트의 기존 SDU 라디오 필터 로직이 쿼리 파라미터로 그대로 전달하므로 **추가 작업이 없었습니다.**

## 주요 변경사항

| 레이어 | 변경 |
|---|---|
| Model | `LocationBoundsResponse` (`southWest` / `northEast`) 추가 |
| Model | `HomeListSectionResponse` 에 nullable `focusBounds` 추가 (수기 `init(from:)` 이라 `CodingKeys` + 디코더 양쪽 수정) |
| ViewModel | `HomeViewModel.Output.focusBounds` 추가 — **첫 페이지 응답에서만** 전달 |
| View | `HomeView.moveCamera(bounds:)` — `NMGLatLngBounds` + `NMFCameraUpdate(fit:paddingInsets:)` |
| ViewController | `output.focusBounds` 바인딩 |

### 구현 판단 2가지

- **첫 페이지에서만 카메라 이동**: 페이지네이션 응답에도 `focusBounds` 가 실려 오는데, 매 페이지마다 카메라를 옮기면 사용자가 리스트를 훑는 도중 지도가 튑니다.
- **paddingInsets 사용** (`padding:` 대신): `mapView` 는 화면 전체를 덮지만 상단은 주소/필터 바가, 하단은 바텀시트가 가립니다. 실제 가시 영역 기준으로 인셋을 줘야 마커가 UI 뒤에 숨지 않습니다.

프로그래밍 방식 카메라 이동은 `NMFMapChangedByGesture` 가 아니므로 "이 지역 재검색" 버튼이나 재조회 루프를 유발하지 않습니다.

## 테스트

### 유닛 테스트 — 4개 통과

`HomeListSectionResponseTests` (dev 서버 실응답 캡처 픽스처 기반)

- `focusBounds` 파싱 (좌표 4개 값 검증)
- `focusBounds` 없는 응답 → `nil`, `cards`/`cursor` 정상
- `focusBounds` 유/무 응답의 `cards`·`cursor` 파싱 동일 (회귀)
- 남서 == 북동 (넓이 0) 경계 케이스

```
Executed 4 tests, with 0 failures
** TEST SUCCEEDED **
```

### 시뮬레이터 검증 (iPhone 17 Pro / 위치: 서울시청)

서버가 테스트용으로 추가해준 **"(테스트) 지도 포커싱"** 필터 칩으로 확인했습니다.

| 1. 필터 OFF (기존) | 2. 필터 ON — focusBounds 적용 | 3. 필터 다시 OFF |
|---|---|---|
| <img src="https://raw.githubusercontent.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/assets/TH-1261-screenshots/screenshots/TH-1261/01-before-filter-off.png" width="260"> | <img src="https://raw.githubusercontent.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/assets/TH-1261-screenshots/screenshots/TH-1261/02-after-filter-on-focusbounds.png" width="260"> | <img src="https://raw.githubusercontent.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/assets/TH-1261-screenshots/screenshots/TH-1261/03-filter-off-camera-stays.png" width="260"> |
| 기본 줌(15). 광화문~시청 광역 뷰, 마커가 한 덩어리로 뭉쳐 있음 | 서울광장 일대로 확대. 마커가 펼쳐지고, 필터바·바텀시트에 가리지 않는 영역에 모두 들어옴 | 카메라 그대로 유지 (`focusBounds` 없음 → 이동 없음). 리스트만 재조회 |

실제 dev 응답:

```json
"focusBounds": {
  "southWest": { "latitude": 37.56566954184981, "longitude": 126.977966 },
  "northEast": { "latitude": 37.5666,           "longitude": 126.97871680558559 }
}
```

## 참고

- PR 본문 스크린샷은 diff 를 더럽히지 않도록 별도 브랜치 `assets/TH-1261-screenshots` 에 올려두었습니다. 머지 후 삭제해도 됩니다.
- 빌드(`three-dollar-in-my-pocket-debug`) / 테스트(`three-dollar-in-my-pocketTests`) / SwiftLint 모두 통과했습니다.


[TH-1261]: https://3dollarinmypocket.atlassian.net/browse/TH-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ